### PR TITLE
Add record type option to --probe

### DIFF
--- a/pkg/sidecar/dnsprobe.go
+++ b/pkg/sidecar/dnsprobe.go
@@ -153,7 +153,7 @@ func (p *dnsProbe) msg() (msg *dns.Msg) {
 	msg.Question = make([]dns.Question, 1)
 	msg.Question[0] = dns.Question{
 		Name:   p.Name,
-		Qtype:  dns.TypeANY,
+		Qtype:  p.Type,
 		Qclass: dns.ClassINET,
 	}
 	return

--- a/pkg/sidecar/dnsprobe_test.go
+++ b/pkg/sidecar/dnsprobe_test.go
@@ -47,6 +47,7 @@ func makeOptions(label string, addr string, port int) *Options {
 				Server:   fmt.Sprintf("%v:%v", addr, port),
 				Name:     "test.local.",
 				Interval: 1 * time.Millisecond,
+				Type:     dns.TypeANY,
 			},
 		},
 	}

--- a/pkg/sidecar/options.go
+++ b/pkg/sidecar/options.go
@@ -28,6 +28,8 @@ type DNSProbeOption struct {
 	Name string
 	// Interval to use for probing
 	Interval time.Duration
+	// Type of Record to query for.
+	Type uint16
 }
 
 // Options for the daemon


### PR DESCRIPTION
This allows for the query to be customized. kube-dns currently does
not handle ANY queries properly.