### PR TITLE
fix kubecfg-file flag description of kube-dns

### DIFF
--- a/cmd/kube-dns/app/options/options.go
+++ b/cmd/kube-dns/app/options/options.go
@@ -140,8 +140,8 @@ func (s *KubeDNSConfig) AddFlags(fs *pflag.FlagSet) {
 
 	fs.StringVar(&s.KubeConfigFile, "kubecfg-file", s.KubeConfigFile,
 		"Location of kubecfg file for access to kubernetes master service;"+
-			" --kube-master-url overrides the URL part of this; if neither this nor"+
-			" --kube-master-url are provided, defaults to service account tokens")
+			" --kube-master-url overrides the URL part of this; if this is not"+
+			" provided, defaults to service account tokens")
 	fs.Var(kubeMasterURLVar{&s.KubeMasterURL}, "kube-master-url",
 		"URL to reach kubernetes master. Env variables in this flag will be expanded.")
 


### PR DESCRIPTION
this pr is same with https://github.com/kubernetes/kubernetes/pull/39314 that was not merged yet before moving codes of kube-dns to here.
so i open new one.