### PR TITLE
Call Parse() to avoid noisy logs.

### DIFF
--- a/cmd/kube-dns/dns.go
+++ b/cmd/kube-dns/dns.go
@@ -17,6 +17,8 @@ limitations under the License.
 package main
 
 import (
+	goflag "flag"
+
 	"github.com/golang/glog"
 	"github.com/spf13/pflag"
 
@@ -36,6 +38,9 @@ func main() {
 	config.AddFlags(pflag.CommandLine)
 
 	flag.InitFlags()
+	// Convinces goflags that we have called Parse() to avoid noisy logs.
+	// OSS Issue: kubernetes/kubernetes#17162.
+	goflag.CommandLine.Parse([]string{})
 	logs.InitLogs()
 	defer logs.FlushLogs()
 


### PR DESCRIPTION
Saw noisy logs from kube-dns on the latest k8s cluster:
```
ERROR: logging before flag.Parse: I0113 02:27:21.529444       1 dns.go:267] New service: kubernetes-dashboard
ERROR: logging before flag.Parse: I0113 02:27:21.529467       1 dns.go:267] New service: kube-dns
ERROR: logging before flag.Parse: I0113 02:27:21.529490       1 dns.go:377] Added SRV record &{Host:kube-dns.kube-system.svc.cluster.local. Port:53 Priority:10 Weight:10 Text: Mail:false Ttl:30 TargetStrip:0 Group: Key:}
ERROR: logging before flag.Parse: I0113 02:27:21.529510       1 dns.go:377] Added SRV record &{Host:kube-dns.kube-system.svc.cluster.local. Port:53 Priority:10 Weight:10 Text: Mail:false Ttl:30 TargetStrip:0 Group: Key:}
ERROR: logging before flag.Parse: I0113 02:27:21.529533       1 dns.go:267] New service: kubernetes
ERROR: logging before flag.Parse: I0113 02:27:21.529554       1 dns.go:377] Added SRV record &{Host:kubernetes.default.svc.cluster.local. Port:443 Priority:10 Weight:10 Text: Mail:false Ttl:30 TargetStrip:0 Group: Key:}
ERROR: logging before flag.Parse: I0113 02:27:21.529579       1 dns.go:267] New service: default-http-backend
ERROR: logging before flag.Parse: I0113 02:27:21.529601       1 dns.go:377] Added SRV record &{Host:default-http-backend.kube-system.svc.cluster.local. Port:80 Priority:10 Weight:10 Text: Mail:false Ttl:30 TargetStrip:0 Group: Key:}
ERROR: logging before flag.Parse: I0113 02:27:21.529623       1 dns.go:267] New service: monitoring-grafana
```

Found a workaround from kubernetes/kubernetes#17162, also adopts it here. The noisy logs seems to be introduced by golang/glog@65d6746.

@bowei 