### PR TITLE
Fixed sidecar running group for arm arch

### DIFF
--- a/Dockerfile.sidecar
+++ b/Dockerfile.sidecar
@@ -18,5 +18,5 @@ MAINTAINER Bowei Du <bowei@google.com>
 
 ADD bin/ARG_ARCH/ARG_BIN /ARG_BIN
 
-USER nobody:nobody
+USER nobody:ARG_NOBODY
 ENTRYPOINT ["/ARG_BIN"]

--- a/Dockerfile.sidecar-e2e
+++ b/Dockerfile.sidecar-e2e
@@ -18,5 +18,5 @@ MAINTAINER Bowei Du <bowei@google.com>
 
 ADD bin/ARG_ARCH/ARG_BIN /ARG_BIN
 
-USER nobody:nobody
+USER nobody:ARG_NOBODY
 ENTRYPOINT ["/ARG_BIN"]

--- a/rules.mk
+++ b/rules.mk
@@ -31,15 +31,19 @@ ALL_ARCH := amd64 arm arm64 ppc64le
 # Set default base image dynamically for each arch
 ifeq ($(ARCH),amd64)
     BASEIMAGE?=alpine
+    NOBODY?=nobody
 endif
 ifeq ($(ARCH),arm)
     BASEIMAGE?=armel/busybox
+    NOBODY?=nogroup
 endif
 ifeq ($(ARCH),arm64)
     BASEIMAGE?=aarch64/busybox
+    NOBODY?=nogroup
 endif
 ifeq ($(ARCH),ppc64le)
     BASEIMAGE?=ppc64le/busybox
+    NOBODY?=nobody
 endif
 
 # These rules MUST be expanded at reference time (hence '=') as BINARY
@@ -114,6 +118,7 @@ define DOCKERFILE_RULE
 	    -e 's|ARG_BIN|$(BINARY)|g'		\
 	    -e 's|ARG_ARCH|$(ARCH)|g'		\
 	    -e 's|ARG_FROM|$(BASEIMAGE)|g'	\
+	    -e 's|ARG_NOBODY|$(NOBODY)|g'	\
 	    $$< > $$@
 .$(BUILDSTAMP_NAME)-container: .$(BINARY)-$(ARCH)-dockerfile
 endef


### PR DESCRIPTION
The base image used to build the containers for the arm arch
(both arm and arm64) uses the pair nobody:nogroup while amd64
arch uses nobody:nobody