### PR TITLE
Add support for pulling config from a directory

### DIFF
--- a/cmd/kube-dns/app/options/options.go
+++ b/cmd/kube-dns/app/options/options.go
@@ -46,6 +46,9 @@ type KubeDNSConfig struct {
 
 	ConfigMapNs string
 	ConfigMap   string
+
+	ConfigDir    string
+	ConfigPeriod time.Duration
 }
 
 func NewKubeDNSConfig() *KubeDNSConfig {
@@ -60,6 +63,9 @@ func NewKubeDNSConfig() *KubeDNSConfig {
 
 		ConfigMapNs: api.NamespaceSystem,
 		ConfigMap:   "", // default to using command line flags
+
+		ConfigPeriod: 10 * time.Second,
+		ConfigDir:    "",
 	}
 }
 
@@ -155,15 +161,21 @@ func (s *KubeDNSConfig) AddFlags(fs *pflag.FlagSet) {
 		"a comma separated list of the federation names and their corresponding"+
 			" domain names to which this cluster belongs. Example:"+
 			" \"myfederation1=example.com,myfederation2=example2.com,myfederation3=example.com\"."+
-			" It is an error to set both the federations and config-map flags.")
-	fs.MarkDeprecated("federations", "use config-map instead. Will be removed in future version")
+			" It is an error to set both the federations and config-map or config-dir flags.")
+	fs.MarkDeprecated("federations", "use config-dir instead. Will be removed in future version")
 
 	fs.StringVar(&s.ConfigMapNs, "config-map-namespace", s.ConfigMapNs,
 		"namespace for the config-map")
 	fs.StringVar(&s.ConfigMap, "config-map", s.ConfigMap,
 		"config-map name. If empty, then the config-map will not used. Cannot be "+
-			" used in conjunction with federations flag. config-map contains "+
+			"used in conjunction with federations or config-dir flag. config-map contains "+
 			"dynamically adjustable configuration.")
 	fs.DurationVar(&s.InitialSyncTimeout, "initial-sync-timeout", s.InitialSyncTimeout,
 		"Timeout for initial resource sync.")
+
+	fs.StringVar(&s.ConfigDir, "config-dir", s.ConfigDir,
+		"directory to read config values from. Cannot be "+
+			"used in conjunction with federations or config-map flag.")
+	fs.DurationVar(&s.ConfigPeriod, "config-period", s.ConfigPeriod,
+		"period at which to check for updates in config-dir.")
 }

--- a/cmd/kube-dns/app/server.go
+++ b/cmd/kube-dns/app/server.go
@@ -54,12 +54,19 @@ func NewKubeDNSServerDefault(config *options.KubeDNSConfig) *KubeDNSServer {
 
 	var configSync dnsconfig.Sync
 	switch {
+	case config.ConfigMap != "" && config.ConfigDir != "":
+		glog.Fatal("Cannot use both ConfigMap and ConfigDir")
+
 	case config.ConfigMap != "":
 		glog.V(0).Infof("Using configuration read from ConfigMap: %v:%v", config.ConfigMapNs, config.ConfigMap)
 		configSync = dnsconfig.NewConfigMapSync(kubeClient, config.ConfigMapNs, config.ConfigMap)
 
+	case config.ConfigDir != "":
+		glog.V(0).Infof("Using configuration read from directory: %v", config.ConfigDir, config.ConfigPeriod)
+		configSync = dnsconfig.NewFileSync(config.ConfigDir, config.ConfigPeriod)
+
 	default:
-		glog.V(0).Infof("ConfigMap not configured, using values from command line flags")
+		glog.V(0).Infof("ConfigMap and ConfigDir not configured, using values from command line flags")
 		configSync = dnsconfig.NewNopSync(&dnsconfig.Config{Federations: config.Federations})
 	}
 

--- a/pkg/dns/config/sync_configmap.go
+++ b/pkg/dns/config/sync_configmap.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/pkg/api/v1"
+	metav1 "k8s.io/client-go/pkg/apis/meta/v1"
+	"k8s.io/client-go/pkg/fields"
+	"k8s.io/client-go/pkg/runtime"
+	"k8s.io/client-go/pkg/util/wait"
+	"k8s.io/client-go/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+
+	"time"
+
+	"github.com/golang/glog"
+)
+
+// NewConfigMapSync returns a Sync that watches a config map in the API
+func NewConfigMapSync(client kubernetes.Interface, ns string, name string) Sync {
+	syncSource := &kubeAPISyncSource{
+		ns:      ns,
+		name:    name,
+		client:  client,
+		channel: make(chan syncResult),
+	}
+
+	listWatch := &cache.ListWatch{
+		ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
+			options.FieldSelector = fields.Set{"metadata.name": name}.AsSelector().String()
+			return client.Core().ConfigMaps(ns).List(options)
+		},
+		WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+			options.FieldSelector = fields.Set{"metadata.name": name}.AsSelector().String()
+			return client.Core().ConfigMaps(ns).Watch(options)
+		},
+	}
+
+	store, controller := cache.NewInformer(
+		listWatch,
+		&v1.ConfigMap{},
+		time.Duration(0),
+		cache.ResourceEventHandlerFuncs{
+			AddFunc:    syncSource.onAdd,
+			DeleteFunc: syncSource.onDelete,
+			UpdateFunc: syncSource.onUpdate,
+		})
+
+	syncSource.store = store
+	syncSource.controller = controller
+
+	return newSync(syncSource)
+}
+
+type kubeAPISyncSource struct {
+	ns   string
+	name string
+
+	client     kubernetes.Interface
+	store      cache.Store
+	controller *cache.Controller
+
+	channel chan syncResult
+}
+
+var _ syncSource = (*kubeAPISyncSource)(nil)
+
+func (syncSource *kubeAPISyncSource) Once() (syncResult, error) {
+	cm, err := syncSource.client.Core().ConfigMaps(syncSource.ns).Get(syncSource.name, metav1.GetOptions{})
+	if err != nil {
+		glog.Errorf("Error getting ConfigMap %v:%v err: %v", syncSource.ns, syncSource.name, err)
+		return syncResult{}, err
+	}
+	return syncResult{Version: cm.ResourceVersion, Data: cm.Data}, nil
+}
+
+func (syncSource *kubeAPISyncSource) Periodic() <-chan syncResult {
+	go syncSource.controller.Run(wait.NeverStop)
+	return syncSource.channel
+}
+
+func (syncSource *kubeAPISyncSource) toConfigMap(obj interface{}) *v1.ConfigMap {
+	cm, ok := obj.(*v1.ConfigMap)
+	if !ok {
+		glog.Fatalf("Expected ConfigMap, got %T", obj)
+	}
+	return cm
+}
+
+func (syncSource *kubeAPISyncSource) onAdd(obj interface{}) {
+	cm := syncSource.toConfigMap(obj)
+	glog.V(2).Infof("ConfigMap %s:%s was created", syncSource.ns, syncSource.name)
+	syncSource.channel <- syncResult{Version: cm.ResourceVersion, Data: cm.Data}
+}
+
+func (syncSource *kubeAPISyncSource) onDelete(_ interface{}) {
+	glog.V(2).Infof("ConfigMap %s:%s was deleted, reverting to default configuration", syncSource.ns, syncSource.name)
+	syncSource.channel <- syncResult{Version: "", Data: nil}
+}
+
+func (syncSource *kubeAPISyncSource) onUpdate(_, obj interface{}) {
+	cm := syncSource.toConfigMap(obj)
+	glog.V(2).Infof("ConfigMap %s:%s was updated", syncSource.ns, syncSource.name)
+	syncSource.channel <- syncResult{Version: cm.ResourceVersion, Data: cm.Data}
+}

--- a/pkg/dns/config/sync_dir.go
+++ b/pkg/dns/config/sync_dir.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/golang/glog"
+
+	"k8s.io/client-go/pkg/util/clock"
+)
+
+// NewFileSync returns a Sync that scans the given dir periodically for config data
+func NewFileSync(dir string, period time.Duration) Sync {
+	return newSync(newFileSyncSource(dir, period, clock.RealClock{}))
+}
+
+// newFileSyncSource returns a syncSource that scans the given dir periodically as determined by the specified clock
+func newFileSyncSource(dir string, period time.Duration, clock clock.Clock) syncSource {
+	return &kubeFileSyncSource{
+		dir:     dir,
+		clock:   clock,
+		period:  period,
+		channel: make(chan syncResult),
+	}
+}
+
+type kubeFileSyncSource struct {
+	dir     string
+	clock   clock.Clock
+	period  time.Duration
+	channel chan syncResult
+}
+
+var _ syncSource = (*kubeFileSyncSource)(nil)
+
+func (syncSource *kubeFileSyncSource) Once() (syncResult, error) {
+	return syncSource.load()
+}
+
+func (syncSource *kubeFileSyncSource) Periodic() <-chan syncResult {
+	// TODO: drive via inotify?
+	go func() {
+		ticker := syncSource.clock.Tick(syncSource.period)
+		for {
+			if result, err := syncSource.load(); err != nil {
+				glog.Errorf("Error loading config from %s: %v", syncSource.dir, err)
+			} else {
+				syncSource.channel <- result
+			}
+			<-ticker
+		}
+	}()
+	return syncSource.channel
+}
+
+func (syncSource *kubeFileSyncSource) load() (syncResult, error) {
+	hasher := sha256.New()
+	data := map[string]string{}
+	err := filepath.Walk(syncSource.dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// special case for the root
+		if path == syncSource.dir {
+			if info.IsDir() {
+				return nil
+			}
+			return fmt.Errorf("config path %q is not a directory", path)
+		}
+
+		// don't recurse
+		if info.IsDir() {
+			return filepath.SkipDir
+		}
+		// skip hidden files
+		filename := filepath.Base(path)
+		if strings.HasPrefix(filename, ".") {
+			return nil
+		}
+		filedata, err := ioutil.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		if !utf8.Valid(filedata) {
+			return fmt.Errorf("non-utf8 data in %s", path)
+		}
+
+		// Add data to version hash
+		hasher.Write([]byte(filename))
+		hasher.Write([]byte{0})
+		hasher.Write(filedata)
+		hasher.Write([]byte{0})
+
+		// Add data to map
+		data[filename] = string(filedata)
+
+		return nil
+	})
+	if err != nil {
+		return syncResult{}, err
+	}
+
+	// compute a version string from the hashed data
+	version := ""
+	if len(data) > 0 {
+		version = fmt.Sprintf("%x", hasher.Sum(nil))
+	}
+
+	return syncResult{Version: version, Data: data}, nil
+}

--- a/pkg/dns/config/sync_dir_test.go
+++ b/pkg/dns/config/sync_dir_test.go
@@ -1,0 +1,166 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+
+	"os"
+
+	"crypto/sha256"
+
+	"k8s.io/client-go/pkg/util/clock"
+)
+
+func TestSyncFile(t *testing.T) {
+
+	testParentDir, err := ioutil.TempDir("", "test.filesyncsource")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { os.RemoveAll(testParentDir) }()
+
+	testDir := filepath.Join(testParentDir, "datadir")
+
+	fakeClock := clock.NewFakeClock(time.Now())
+
+	source := newFileSyncSource(testDir, time.Second, fakeClock)
+
+	// missing dir should error
+	if _, err := source.Once(); err == nil {
+		t.Fatalf("expected error reading missing dir")
+	}
+
+	// empty dir should return empty results
+	if err := os.Mkdir(testDir, os.FileMode(0755)); err != nil {
+		t.Fatal(err)
+	}
+	result, err := source.Once()
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if result.Version != "" || len(result.Data) != 0 {
+		t.Fatalf("expected empty version and data reading empty dir, got %#v", result)
+	}
+
+	// should not recurse and should ignore dot files
+	if err := os.Mkdir(filepath.Join(testDir, "subdir"), os.FileMode(0755)); err != nil {
+		t.Fatal(err)
+	}
+	if err := ioutil.WriteFile(filepath.Join(testDir, "subdir", "subdirfile"), []byte("test"), os.FileMode(0755)); err != nil {
+		t.Fatal(err)
+	}
+	if err := ioutil.WriteFile(filepath.Join(testDir, ".hiddenfile"), []byte("test"), os.FileMode(0755)); err != nil {
+		t.Fatal(err)
+	}
+	result, err = source.Once()
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if result.Version != "" || len(result.Data) != 0 {
+		t.Fatalf("expected empty version and data reading dir containing subdirs and dotfiles, got %#v", result)
+	}
+
+	// should return error if non-utf8 data is encountered
+	// https://en.wikipedia.org/wiki/UTF-8#Codepage_layout
+	if err := ioutil.WriteFile(filepath.Join(testDir, "binary"), []byte{192}, os.FileMode(0755)); err != nil {
+		t.Fatal(err)
+	}
+	result, err = source.Once()
+	if err == nil {
+		t.Fatalf("expected error reading dir containing binary data")
+	}
+	if err := os.Remove(filepath.Join(testDir, "binary")); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ioutil.WriteFile(filepath.Join(testDir, "file1"), []byte("data1"), os.FileMode(0755)); err != nil {
+		t.Fatal(err)
+	}
+	if err := ioutil.WriteFile(filepath.Join(testDir, "file2"), []byte("data2"), os.FileMode(0755)); err != nil {
+		t.Fatal(err)
+	}
+	result, err = source.Once()
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	expectedResult := syncResult{
+		Version: fmt.Sprintf("%x", sha256.Sum256([]byte("file1\x00data1\x00file2\x00data2\x00"))),
+		Data:    map[string]string{"file1": "data1", "file2": "data2"},
+	}
+	if !reflect.DeepEqual(result, expectedResult) {
+		t.Fatalf("expected %#v, got %#v", expectedResult, result)
+	}
+
+	resultCh := source.Periodic()
+
+	// Result should be available right away
+	select {
+	case periodicResult := <-resultCh:
+		if !reflect.DeepEqual(periodicResult, expectedResult) {
+			t.Fatalf("Expected %#v, got %#v", expectedResult, periodicResult)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for initial data from period sync")
+	}
+
+	// No additional results should be available until time has passed
+	select {
+	case periodicResult := <-resultCh:
+		t.Fatalf("unexpected periodic result before time passed: %#v", periodicResult)
+	case <-time.After(time.Second):
+		// waited and got no result, success
+	}
+
+	// move time forward, check new result
+	fakeClock.Step(time.Second)
+	select {
+	case periodicResult := <-resultCh:
+		if !reflect.DeepEqual(periodicResult, expectedResult) {
+			t.Fatalf("Expected %#v, got %#v", expectedResult, periodicResult)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for periodic data")
+	}
+
+	// modify data
+	if err := os.Remove(filepath.Join(testDir, "file1")); err != nil {
+		t.Fatal(err)
+	}
+	if err := ioutil.WriteFile(filepath.Join(testDir, "file3"), []byte("data3"), os.FileMode(0755)); err != nil {
+		t.Fatal(err)
+	}
+	expectedResult = syncResult{
+		Version: fmt.Sprintf("%x", sha256.Sum256([]byte("file2\x00data2\x00file3\x00data3\x00"))),
+		Data:    map[string]string{"file2": "data2", "file3": "data3"},
+	}
+	// move time forward, check new result
+	fakeClock.Step(time.Second)
+	select {
+	case periodicResult := <-resultCh:
+		if !reflect.DeepEqual(periodicResult, expectedResult) {
+			t.Fatalf("expected %#v, got %#v", expectedResult, periodicResult)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for periodic data")
+	}
+}


### PR DESCRIPTION
now that optional configmaps are possible, kube-dns should support pulling config from a mounted directory

this PR refactors the existing API-based configmap source and adds a directory-based source

c.f.
https://github.com/kubernetes/kubernetes/pull/36775#issuecomment-261412030
https://github.com/kubernetes/kubernetes/pull/38816
https://github.com/kubernetes/kubernetes/pull/39981