### PR TITLE
Make sure that the probe name is a FQDN.

### DIFF
--- a/pkg/sidecar/dnsprobe.go
+++ b/pkg/sidecar/dnsprobe.go
@@ -152,7 +152,7 @@ func (p *dnsProbe) msg() (msg *dns.Msg) {
 	msg.RecursionDesired = true
 	msg.Question = make([]dns.Question, 1)
 	msg.Question[0] = dns.Question{
-		Name:   p.Name,
+		Name:   dns.Fqdn(p.Name),
 		Qtype:  p.Type,
 		Qclass: dns.ClassINET,
 	}


### PR DESCRIPTION
Add the trailing dot if it is missing.  Fixes #49.

Not sure how to test this.  I think it should be pretty darn safe.  Here is the impl of Fqdn: https://github.com/miekg/dns/blob/master/defaults.go#L227.