### PR TITLE
Making k8s-dns-kube-dns and k8s-dns-dnsmasq images available for s390x

### DIFF
--- a/images/dnsmasq/Makefile
+++ b/images/dnsmasq/Makefile
@@ -18,9 +18,9 @@ ARCH ?= amd64
 DNSMASQ_VERSION ?= dnsmasq-2.76
 CONTAINER_PREFIX ?= k8s-dns
 
-ALL_ARCH := amd64 arm arm64 ppc64le
+ALL_ARCH := amd64 arm arm64 ppc64le s390x
 IMAGE := $(CONTAINER_PREFIX)-dnsmasq-$(ARCH)
-COMPILE_IMAGE := gcr.io/google_containers/kube-cross:v1.6.2-2
+COMPILE_IMAGE := gcr.io/google_containers/kube-cross:v1.7.4-1
 OUTPUT_DIR := _output/$(ARCH)
 
 ifeq ($(ARCH),amd64)

--- a/rules.mk
+++ b/rules.mk
@@ -27,7 +27,7 @@ export VERSION
 # directories which hold app source (not vendored)
 SRC_DIRS := cmd pkg
 
-ALL_ARCH := amd64 arm arm64 ppc64le
+ALL_ARCH := amd64 arm arm64 ppc64le s390x
 # Set default base image dynamically for each arch
 ifeq ($(ARCH),amd64)
     BASEIMAGE?=alpine
@@ -43,6 +43,10 @@ ifeq ($(ARCH),arm64)
 endif
 ifeq ($(ARCH),ppc64le)
     BASEIMAGE?=ppc64le/busybox
+    NOBODY?=nobody
+endif
+ifeq ($(ARCH),s390x)
+    BASEIMAGE?=s390x/busybox
     NOBODY?=nobody
 endif
 


### PR DESCRIPTION
In this PR I have changed the version of "gcr.io/google_containers/kube-cross" image. The existing version has Go does not support s390x. With "v1.7.4-1" version it builds the dnsmasq binary and builds successfully for s390x. Also modified s390x support in "rules.mk" and "images/dnsmasq/Makefile"