### PR TITLE
Fix version on startup

### DIFF
--- a/cmd/kube-dns/dns.go
+++ b/cmd/kube-dns/dns.go
@@ -24,10 +24,9 @@ import (
 
 	"k8s.io/dns/cmd/kube-dns/app"
 	"k8s.io/dns/cmd/kube-dns/app/options"
+	"k8s.io/dns/pkg/version"
 	"k8s.io/kubernetes/pkg/util/flag"
 	"k8s.io/kubernetes/pkg/util/logs"
-	"k8s.io/kubernetes/pkg/version"
-	"k8s.io/kubernetes/pkg/version/verflag"
 
 	_ "k8s.io/kubernetes/pkg/client/metrics/prometheus" // for client metric registration
 	_ "k8s.io/kubernetes/pkg/version/prometheus"        // for version metric registration
@@ -44,9 +43,9 @@ func main() {
 	logs.InitLogs()
 	defer logs.FlushLogs()
 
-	verflag.PrintAndExitIfRequested()
+	version.PrintAndExitIfRequested()
 
-	glog.V(0).Infof("version: %+v", version.Get())
+	glog.V(0).Infof("version: %+v", version.VERSION)
 
 	server := app.NewKubeDNSServerDefault(config)
 	server.Run()

--- a/cmd/sidecar/main.go
+++ b/cmd/sidecar/main.go
@@ -28,7 +28,6 @@ import (
 	"github.com/spf13/pflag"
 	"k8s.io/kubernetes/pkg/util/flag"
 	"k8s.io/kubernetes/pkg/util/logs"
-	"k8s.io/kubernetes/pkg/version/verflag"
 
 	"k8s.io/dns/pkg/sidecar"
 	"k8s.io/dns/pkg/version"
@@ -48,7 +47,7 @@ func main() {
 
 	glog.Infof("Version v%s", version.VERSION)
 
-	verflag.PrintAndExitIfRequested()
+	version.PrintAndExitIfRequested()
 
 	server := sidecar.NewServer()
 	server.Run(options)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -16,5 +16,86 @@ limitations under the License.
 
 package version
 
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	flag "github.com/spf13/pflag"
+)
+
 // VERSION of this binary
 var VERSION = "UNKNOWN"
+
+type versionValue int
+
+const (
+	VersionFalse versionValue = 0
+	VersionTrue  versionValue = 1
+	VersionRaw   versionValue = 2
+)
+
+const strRawVersion string = "raw"
+
+func (v *versionValue) IsBoolFlag() bool {
+	return true
+}
+
+func (v *versionValue) Get() interface{} {
+	return versionValue(*v)
+}
+
+func (v *versionValue) Set(s string) error {
+	if s == strRawVersion {
+		*v = VersionRaw
+		return nil
+	}
+	boolVal, err := strconv.ParseBool(s)
+	if boolVal {
+		*v = VersionTrue
+	} else {
+		*v = VersionFalse
+	}
+	return err
+}
+
+func (v *versionValue) String() string {
+	if *v == VersionRaw {
+		return strRawVersion
+	}
+	return fmt.Sprintf("%v", bool(*v == VersionTrue))
+}
+
+// The type of the flag as required by the pflag.Value interface
+func (v *versionValue) Type() string {
+	return "version"
+}
+
+func VersionVar(p *versionValue, name string, value versionValue, usage string) {
+	*p = value
+	flag.Var(p, name, usage)
+	// "--version" will be treated as "--version=true"
+	flag.Lookup(name).NoOptDefVal = "true"
+}
+
+func Version(name string, value versionValue, usage string) *versionValue {
+	p := new(versionValue)
+	VersionVar(p, name, value, usage)
+	return p
+}
+
+var (
+	versionFlag = Version("version", VersionFalse, "Print version information and quit")
+)
+
+// PrintAndExitIfRequested will check if the -version flag was passed
+// and, if so, print the version and exit.
+func PrintAndExitIfRequested() {
+	if *versionFlag == VersionRaw {
+		fmt.Printf("%#v\n", VERSION)
+		os.Exit(0)
+	} else if *versionFlag == VersionTrue {
+		fmt.Printf("Kube-DNS %s\n", VERSION)
+		os.Exit(0)
+	}
+}


### PR DESCRIPTION
Hi,
It seems that during startup the kube-dns service is reporting (static) version of kubernetes:
$ make bin/amd64/kube-dns
building : bin/amd64/kube-dns
$ bin/amd64/kube-dns 
I0317 11:24:42.981414   27628 dns.go:49] version: v1.5.2-beta.0+$Format:%h$
...

which is defined in vendor/k8s.io/kubernetes/pkg/version/base.go and seems rather wrong/useless. We should report kube-dns version instead, which is compiled-in during compile time.

After applying this fix:
$ make bin/amd64/kube-dns
building : bin/amd64/kube-dns
$ bin/amd64/kube-dns 
I0317 11:27:32.043009   30292 dns.go:49] version: 1.14.1-dirty

which looks more appropriate.

Have a nice day,
Ashley