### PR TITLE
Fix printf in cmd/kube-dns/app/server.go

### DIFF
--- a/cmd/kube-dns/app/server.go
+++ b/cmd/kube-dns/app/server.go
@@ -67,7 +67,7 @@ func NewKubeDNSServerDefault(config *options.KubeDNSConfig) *KubeDNSServer {
 		configSync = dnsconfig.NewConfigMapSync(kubeClient, config.ConfigMapNs, config.ConfigMap)
 
 	case config.ConfigDir != "":
-		glog.V(0).Infof("Using configuration read from directory: %v", config.ConfigDir, config.ConfigPeriod)
+		glog.V(0).Infof("Using configuration read from directory: %v with period %v", config.ConfigDir, config.ConfigPeriod)
 		configSync = dnsconfig.NewFileSync(config.ConfigDir, config.ConfigPeriod)
 
 	default:


### PR DESCRIPTION
Fixes logging message
> 2017-04-07T22:56:44.901399945Z I0407 22:56:44.900224       1 server.go:70] Using configuration read from directory: /kube-dns-config%!(EXTRA time.Duration=10s)
