### PR TITLE
Fix confusing logging when initialize server

### DIFF
--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -171,7 +171,7 @@ func (kd *KubeDNS) waitForResourceSyncedOrDie() {
 				glog.V(0).Infof("Initialized services and endpoints from apiserver")
 				return
 			}
-			glog.V(0).Infof("DNS server not ready, retry in 500 milliseconds")
+			glog.V(0).Infof("Waiting for services and endpoints to be initialized from apiserver...")
 		}
 	}
 }


### PR DESCRIPTION
The logging we have when initializing services and endpoints is confusing:
```
DNS server not ready, retry in 500 milliseconds
```

Modify the message a bit to clarify what it is doing.