### PR TITLE
Support kube-master-url flag without kubeconfig

### DIFF
--- a/cmd/kube-dns/app/server.go
+++ b/cmd/kube-dns/app/server.go
@@ -89,7 +89,8 @@ func newKubeClient(dnsConfig *options.KubeDNSConfig) (kubernetes.Interface, erro
 	var config *rest.Config
 	var err error
 
-	if dnsConfig.KubeConfigFile == "" {
+	// If both kubeconfig and master URL are empty, use service account
+	if dnsConfig.KubeConfigFile == "" && dnsConfig.KubeMasterURL == "" {
 		config, err = rest.InClusterConfig()
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
When the `client-go` package was introduced, the `kube-master-url` flag was rendered unusable. With this PR, the user can now specify the master URL without having to provide a kubeconfig file.

Fixes #72 