### PR TITLE
better latency buckets 0.5ms to 9.78s

### DIFF
--- a/pkg/sidecar/dnsprobe.go
+++ b/pkg/sidecar/dnsprobe.go
@@ -90,12 +90,13 @@ func (p *dnsProbe) Start(options *Options) {
 func (p *dnsProbe) registerMetrics(options *Options) {
 	const dnsProbeSubsystem = "probe"
 
+	// create 500 buckets from 0.5ms to 9.7s
 	p.latencyHistogram = prometheus.NewHistogram(prometheus.HistogramOpts{
 		Namespace: options.PrometheusNamespace,
 		Subsystem: dnsProbeSubsystem,
 		Name:      p.Label + "_latency_ms",
 		Help:      "Latency of the DNS probe request " + p.Label,
-		Buckets:   prometheus.LinearBuckets(0, 10, 500),
+		Buckets:   prometheus.ExponentialBuckets(0.5, 1.02, 500),
 	})
 	prometheus.MustRegister(p.latencyHistogram)
 


### PR DESCRIPTION
The current state of latency buckets is a linear progression from 10ms to 5s. I think the bottom end of the latencies are more important especially when probing dnsmasq. This pull request uses exponential buckets starting at 0.5ms and proceeding (with a factor of 1.02) to about 10s.