### PR TITLE
fix assertIsService return result

### DIFF
--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -255,7 +255,7 @@ func assertIsService(obj interface{}) (*v1.Service, bool) {
 		return service, ok
 	} else {
 		glog.Errorf("Type assertion failed! Expected 'Service', got %T", service)
-		return nil, ok
+		return nil, false
 	}
 }
 


### PR DESCRIPTION

```go
func assertIsService(obj interface{}) (*v1.Service, bool) {
	if service, ok := obj.(*v1.Service); ok {
		return service, ok
	} else {
		glog.Errorf("Type assertion failed! Expected 'Service', got %T", service)
		return nil, ok   // should return false
	}
}
```
calling function:

```go
func (kd *KubeDNS) newService(obj interface{}) {
	if service, ok := assertIsService(obj); ok { // if obj is not service object，service is nil, 
        // ....
	
        // if service is nil, but ok is true, service.Spec.Type will panic
        if service.Spec.Type == v1.ServiceTypeExternalName {
		kd.newExternalNameService(service)
		return
	}

       // ....
}
```