### PR TITLE
use armhf instead of armel for ARCH=arm busybox base images (Fixes #111)

### DIFF
--- a/images/dnsmasq/Makefile
+++ b/images/dnsmasq/Makefile
@@ -27,7 +27,7 @@ ifeq ($(ARCH),amd64)
 	BASEIMAGE ?= alpine:3.6
 	COMPILE_IMAGE := alpine:3.6
 else ifeq ($(ARCH),arm)
-	BASEIMAGE ?= armel/busybox:glibc
+	BASEIMAGE ?= armhf/busybox:glibc
 	TRIPLE    ?= arm-linux-gnueabihf
 	QEMUARCH  := arm
 else ifeq ($(ARCH),arm64)

--- a/rules.mk
+++ b/rules.mk
@@ -34,7 +34,7 @@ ifeq ($(ARCH),amd64)
     NOBODY?=nobody
 endif
 ifeq ($(ARCH),arm)
-    BASEIMAGE?=armel/busybox
+    BASEIMAGE?=armhf/busybox
     NOBODY?=nogroup
 endif
 ifeq ($(ARCH),arm64)


### PR DESCRIPTION
(resubmit after signing CLA)...