### PR TITLE
Fix dnsmasq-nanny dockerfile

### DIFF
--- a/Dockerfile.dnsmasq-nanny
+++ b/Dockerfile.dnsmasq-nanny
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM gcr.io/google_containers/k8s-dns-dnsmasq-ARG_ARCH:ARG_VERSION
+FROM ARG_REGISTRY/k8s-dns-dnsmasq-ARG_ARCH:ARG_VERSION
 
 MAINTAINER Bowei Du <bowei@google.com>
 

--- a/rules.mk
+++ b/rules.mk
@@ -126,6 +126,7 @@ define DOCKERFILE_RULE
 	@sed					\
 	    -e 's|ARG_ARCH|$(ARCH)|g' \
 	    -e 's|ARG_BIN|$(BINARY)|g' \
+	    -e 's|ARG_REGISTRY|$(REGISTRY)|g' \
 	    -e 's|ARG_FROM|$(BASEIMAGE)|g' \
 	    -e 's|ARG_NOBODY|$(NOBODY)|g' \
 	    -e 's|ARG_VERSION|$(VERSION)|g' \


### PR DESCRIPTION
dnsmasq-nanny dockerfile should honor user-specified REGISTRY instead of always using `gcr.io/google_containers`.