### PR TITLE
enable http pprof in kube-dns

### DIFF
--- a/cmd/kube-dns/app/server.go
+++ b/cmd/kube-dns/app/server.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/http/pprof"
 	"os"
 	"os/signal"
 	"regexp"
@@ -141,6 +142,12 @@ func (server *KubeDNSServer) setupHandlers() {
 			fmt.Fprint(w, err)
 		}
 	})
+
+	glog.V(0).Infof("Setting up pprof handler (/debug/pprof)")
+	http.HandleFunc("/debug/pprof/", pprof.Index)
+	http.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	http.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	http.HandleFunc("/debug/pprof/trace", pprof.Trace)
 }
 
 // setupSignalHandlers installs signal handler to ignore SIGINT and


### PR DESCRIPTION
I think it is useful for a webserver to have a pprof debug functionality.
So I add this to kube-dns.

Signed-off-by: allencloud <allen.sun@daocloud.io>