### PR TITLE
diagnoser's initial implementation

### DIFF
--- a/Dockerfile.diagnoser
+++ b/Dockerfile.diagnoser
@@ -1,0 +1,20 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM ARG_FROM
+
+MAINTAINER Bowei Du <bowei@google.com>
+
+ADD bin/ARG_ARCH/ARG_BIN /ARG_BIN
+ENTRYPOINT ["/ARG_BIN"]

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,8 @@ BINARIES := \
 CONTAINER_BINARIES := \
     dnsmasq-nanny \
     kube-dns \
-    sidecar
+    sidecar \
+    diagnoser
 
 # List of images to build (contained in images/)
 IMAGES := dnsmasq

--- a/cmd/diagnoser/flags/flags.go
+++ b/cmd/diagnoser/flags/flags.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flags
+
+import (
+	"flag"
+)
+
+const (
+	DefaultSleepTime = 20
+	DefaultExitCode  = 123
+)
+
+// Options captures the command line flags passed
+type Options struct {
+	RunInfo        bool
+	KubeConfigFile string
+	KubeMasterURL  string
+	SleepTime      int
+	ExitCode       int
+}
+
+// Parse analyzes the given flags and return them inside an Options struct
+func Parse() *Options {
+	var (
+		runInfo        = flag.Bool("run-info", true, "run info checks?")
+		kubeConfigFile = flag.String("kubecfg-file", "", "Location of kubecfg file for access to kubernetes master service")
+		kubeMasterURL  = flag.String("kube-master-url", "", "URL to reach master")
+		sleepTime      = flag.Int("sleep-time", DefaultSleepTime, "Time to wait after finishing the tasks and exiting")
+		exitCode       = flag.Int("exit-code", DefaultExitCode, "error exit code to use on exit (because of the error the diagnoser job will be rescheduled)")
+	)
+	flag.Parse()
+
+	return &Options{
+		RunInfo:        *runInfo,
+		KubeConfigFile: *kubeConfigFile,
+		KubeMasterURL:  *kubeMasterURL,
+		SleepTime:      *sleepTime,
+		ExitCode:       *exitCode,
+	}
+}

--- a/cmd/diagnoser/main.go
+++ b/cmd/diagnoser/main.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+	"time"
+
+	"github.com/golang/glog"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/dns/cmd/diagnoser/flags"
+	"k8s.io/dns/cmd/diagnoser/task"
+	"k8s.io/dns/pkg/version"
+	"k8s.io/kubernetes/pkg/util/logs"
+)
+
+func main() {
+	options := flags.Parse()
+
+	logs.InitLogs()
+	defer logs.FlushLogs()
+
+	glog.Infof("Version v%s", version.VERSION)
+
+	version.PrintAndExitIfRequested()
+
+	cs, err := newClientset(options)
+	if err != nil {
+		glog.Fatal(err)
+	}
+
+	if err := run(options, cs); err != nil {
+		glog.Fatal(err)
+	}
+	time.Sleep(time.Duration(options.SleepTime) * time.Second)
+	os.Exit(options.ExitCode)
+}
+
+func run(opt *flags.Options, cs v1.CoreV1Interface) error {
+	ts := task.Bundle()
+
+	for _, t := range ts {
+		if err := t.Run(opt, cs); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func newClientset(opt *flags.Options) (v1.CoreV1Interface, error) {
+	config, err := clientcmd.BuildConfigFromFlags(
+		opt.KubeMasterURL, opt.KubeConfigFile)
+	if err != nil {
+		return nil, err
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	return clientset.CoreV1(), nil
+}

--- a/cmd/diagnoser/task/info.go
+++ b/cmd/diagnoser/task/info.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package task
+
+import (
+	"github.com/golang/glog"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/dns/cmd/diagnoser/flags"
+)
+
+type info struct{}
+
+func init() {
+	register(&info{})
+}
+
+func (i *info) Run(opt *flags.Options, cs v1.CoreV1Interface) error {
+	if !opt.RunInfo {
+		return nil
+	}
+
+	dnsPods, err := cs.Pods("kube-system").List(meta_v1.ListOptions{
+		LabelSelector: `k8s-app=kube-dns`})
+	if err != nil {
+		return err
+	}
+
+	glog.Infof("Total DNS pods: %d", len(dnsPods.Items))
+
+	return nil
+}

--- a/cmd/diagnoser/task/main.go
+++ b/cmd/diagnoser/task/main.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package task
+
+import (
+	"k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/dns/cmd/diagnoser/flags"
+)
+
+var bundle []Task
+
+// Task represents the checks to be done
+type Task interface {
+	Run(*flags.Options, v1.CoreV1Interface) error
+}
+
+// register adds a task to the set
+func register(t Task) {
+	bundle = append(bundle, t)
+}
+
+// Bundle returns the current set
+func Bundle() []Task {
+	return bundle
+}

--- a/manifests/diagnoser-job.yaml
+++ b/manifests/diagnoser-job.yaml
@@ -1,0 +1,13 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: diagnoser
+spec:
+  template:
+    metadata:
+      name: diagnoser
+    spec:
+      containers:
+      - name: diagnoser
+        image: gcr.io/google_containers/k8s-dns-diagnoser-amd64:1.14.30
+      restartPolicy: Never

--- a/pkg/e2e/diagnoser/diagnoser.go
+++ b/pkg/e2e/diagnoser/diagnoser.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package diagnoser
+
+import (
+	"bufio"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+
+	"k8s.io/dns/pkg/e2e"
+)
+
+// Diagnoser task executor
+type Diagnoser struct {
+	cmd       *exec.Cmd
+	CmdErr    error
+	IsRunning bool
+}
+
+// Start diagnoser tasks, passing in extra arguments
+func (d *Diagnoser) Start(args ...string) {
+	fr := e2e.GetFramework()
+	bin := fr.Path("bin/amd64/diagnoser")
+
+	args = append(args,
+		"--kubecfg-file", fr.Path("test/e2e/cluster/config"),
+		"--sleep-time", "0")
+
+	var err error
+	d.cmd, err = fr.RunInBackground("diagnoser", bin, args...)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	d.IsRunning = true
+
+	go func() {
+		d.CmdErr = d.cmd.Wait()
+		d.IsRunning = false
+	}()
+
+	e2e.Log.Logf("diagnoser started")
+}
+
+// CheckLog returns a scanner to check
+func (d *Diagnoser) CheckLog(needle string) bool {
+	fr := e2e.GetFramework()
+
+	f, err := os.Open(fr.StderrLogfile("diagnoser"))
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		if strings.Contains(scanner.Text(), needle) {
+			return true
+		}
+	}
+	return false
+}

--- a/test/e2e/diagnoser/diagnoser.go
+++ b/test/e2e/diagnoser/diagnoser.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package diagnoser
+
+import (
+	"fmt"
+	"os/exec"
+	"syscall"
+
+	. "github.com/onsi/ginkgo"
+	om "github.com/onsi/gomega"
+	"k8s.io/dns/cmd/diagnoser/flags"
+	"k8s.io/dns/pkg/e2e/diagnoser"
+)
+
+var _ = Describe("diagnoser", func() {
+	diagnoser := &diagnoser.Diagnoser{}
+
+	Context("basic functionality", func() {
+		It("should start", func() {
+			diagnoser.Start()
+			om.Eventually(func() error {
+				expected := "Version v"
+
+				if diagnoser.CheckLog(expected) {
+					return nil
+				}
+
+				return fmt.Errorf("expected %q not found in logs", expected)
+			}).Should(om.Succeed())
+		})
+		It("should exit with error, so that the job gets rescheduled", func() {
+			om.Eventually(func() error {
+				if diagnoser.IsRunning {
+					return fmt.Errorf("diagnoser still running")
+				}
+				if diagnoser.CmdErr == nil {
+					return fmt.Errorf("diagnoser succeeded")
+				}
+
+				exiterr, ok := diagnoser.CmdErr.(*exec.ExitError)
+				if !ok {
+					return fmt.Errorf("diagnoser error is not an exit error")
+				}
+				// The program has exited with an exit code != 0
+
+				// This works on both Unix and Windows. Although package
+				// syscall is generally platform dependent, WaitStatus is
+				// defined for both Unix and Windows and in both cases has
+				// an ExitStatus() method with the same signature.
+				status, ok := exiterr.Sys().(syscall.WaitStatus)
+				if ok && status.ExitStatus() == flags.DefaultExitCode {
+					return nil
+				}
+				return diagnoser.CmdErr
+			}).Should(om.Succeed())
+		})
+	})
+	Context("diagnosis tasks", func() {
+		It("should return generic info", func() {
+			om.Eventually(func() error {
+				const expected = "Total DNS pods: 0"
+
+				if diagnoser.CheckLog(expected) {
+					return nil
+				}
+
+				return fmt.Errorf("expected %q not found in logs", expected)
+			}).Should(om.Succeed())
+		})
+	})
+})

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -31,6 +31,7 @@ import (
 	"testing"
 
 	// Each suite must be imported explicitly.
+	_ "k8s.io/dns/test/e2e/diagnoser"
 	_ "k8s.io/dns/test/e2e/dnsmasq"
 	_ "k8s.io/dns/test/e2e/kubedns"
 )


### PR DESCRIPTION
This is an initial and unfinished implementation of the tool described in kubernetes/kubernetes#45934 and #102, the aim is to validate the approach before implementing all the suggested checks.