### PR TITLE
code refactor

### DIFF
--- a/pkg/sidecar/server.go
+++ b/pkg/sidecar/server.go
@@ -56,10 +56,10 @@ func (s *server) Run(options *Options) {
 func (s *server) runMetrics(options *Options) {
 	InitializeMetrics(options)
 
-	client := dnsmasq.NewMetricsClient(options.DnsMasqAddr, options.DnsMasqPort)
+	s.metricsClient = dnsmasq.NewMetricsClient(options.DnsMasqAddr, options.DnsMasqPort)
 
 	for {
-		metrics, err := client.GetMetrics()
+		metrics, err := s.metricsClient.GetMetrics()
 		if err != nil {
 			glog.Warningf("Error getting metrics from dnsmasq: %v", err)
 			errorsCounter.Add(1)


### PR DESCRIPTION
This PR refactor the code to use `metricsClient` struct field instead of a local variable `client`.

/cc @bowei 