### PR TITLE
Fix: update `kube2sky` to `kube-dns` in comment of server.go 

### DIFF
--- a/cmd/kube-dns/app/server.go
+++ b/cmd/kube-dns/app/server.go
@@ -125,7 +125,7 @@ func (server *KubeDNSServer) Run() {
 	glog.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", server.healthzPort), nil))
 }
 
-// setupHandlers sets up a readiness and liveness endpoint for kube2sky.
+// setupHandlers sets up a readiness and liveness endpoint for kube-dns.
 func (server *KubeDNSServer) setupHandlers() {
 	glog.V(0).Infof("Setting up Healthz Handler (/readiness)")
 	http.HandleFunc("/readiness", func(w http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
I think the  `kube2sky` should be  `kube-dns`, so I fix it.