### PR TITLE
fix kube-dns e2e test for health check service

### DIFF
--- a/pkg/e2e/dns/dns.go
+++ b/pkg/e2e/dns/dns.go
@@ -59,8 +59,18 @@ func (kd *KubeDNS) Start(args ...string) {
 		kd.isRunning = false
 	}()
 
+	// dns service
 	om.Eventually(func() error {
 		conn, err := net.Dial("tcp", "localhost:10053")
+		if err == nil {
+			conn.Close()
+		}
+		return err
+	}).Should(om.Succeed())
+
+	// health check service
+	om.Eventually(func() error {
+		conn, err := net.Dial("tcp", "localhost:8081")
 		if err == nil {
 			conn.Close()
 		}


### PR DESCRIPTION
Fix #138 .

Add health check service validation before doing a query in kube-dns e2e query.

As for now, #139 has not been merged, so this PR will definitely does not pass the CI. But after #139 is merged, i will rebase this PR.

/cc @bowei @feiskyer @MrHohn 