### PR TITLE
fix make file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,14 +19,14 @@
 # Golang package.
 PKG := k8s.io/dns
 
-# List of binaries to build. You must have a matching Dockerfile.BINARY
-# for each BINARY.
+# List of binaries to build.
 BINARIES := \
     e2e \
     ginkgo \
     sidecar-e2e
 
 # List of binaries to build that are containerized and pushed.
+# You must have a matching Dockerfile.BINARY for each BINARY.
 CONTAINER_BINARIES := \
     dnsmasq-nanny \
     kube-dns \

--- a/build/build.sh
+++ b/build/build.sh
@@ -32,6 +32,9 @@ fi
 
 export CGO_ENABLED=0
 export GOARCH="${ARCH}"
+if [ $GOARCH == "amd64" ]; then
+    export GOBIN="$GOPATH/bin/linux_amd64"
+fi
 
 go install                                                         \
     -installsuffix "static"                                        \

--- a/rules.mk
+++ b/rules.mk
@@ -102,7 +102,6 @@ $(GO_BINARIES): build-dirs
 	    -u $$(id -u):$$(id -g)                                             \
 	    -v $$(pwd)/.go:/go                                                 \
 	    -v $$(pwd):/go/src/$(PKG)                                          \
-	    -v $$(pwd)/bin/$(ARCH):/go/bin                                     \
 	    -v $$(pwd)/bin/$(ARCH):/go/bin/linux_$(ARCH)                       \
 	    -v $$(pwd)/.go/std/$(ARCH):/usr/local/go/pkg/linux_$(ARCH)_static  \
 	    -w /go/src/$(PKG)                                                  \


### PR DESCRIPTION
remove useless build volume mapping when build binaries.

By removing `-v $$(pwd)/bin/$(ARCH):/go/bin`, we can avoid an empty dir  `bin/ARCH/linux_ARCH`.

/cc @bowei 