### PR TITLE
Add ability to apply custom patches to the dnsmasq build

### DIFF
--- a/images/dnsmasq/Dockerfile.cross
+++ b/images/dnsmasq/Dockerfile.cross
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 FROM __BASEIMAGE__
-MAINTAINER Bowei Du <bowei@google.com>
 
 # If we're building for another architecture than amd64, the
 # CROSS_BUILD_ placeholder is removed so e.g. CROSS_BUILD_COPY turns

--- a/images/dnsmasq/Makefile
+++ b/images/dnsmasq/Makefile
@@ -15,7 +15,7 @@
 VERSION ?= $(shell git describe --tags --always --dirty)
 REGISTRY ?= gcr.io/google-containers
 ARCH ?= amd64
-DNSMASQ_VERSION ?= dnsmasq-2.76
+DNSMASQ_VERSION ?= dnsmasq-2.77
 CONTAINER_PREFIX ?= k8s-dns
 
 ALL_ARCH := amd64 arm arm64 ppc64le s390x
@@ -57,7 +57,8 @@ ifeq ($(findstring gcr.io/,$(REGISTRY)),gcr.io/)
 	DOCKER := gcloud docker --
 endif
 
-BINARY:= $(OUTPUT_DIR)/dnsmasq
+PATCHES := $(shell find patches/ -name *.patch)
+BINARY := $(OUTPUT_DIR)/docker/dnsmasq
 
 BUILDSTAMP := $(subst :,_,$(subst /,_,$(REGISTRY))_$(IMAGE)_$(VERSION))
 CONTAINER_STAMP := .$(BUILDSTAMP)-container
@@ -98,47 +99,49 @@ all-push: $(addprefix push-, $(ALL_ARCH))
 .PHONY: build
 build: $(BINARY)
 
-$(BINARY): Dockerfile.cross $(DNSMASQ_ARCHIVE) dnsmasq.conf
+$(BINARY): Dockerfile.cross $(DNSMASQ_ARCHIVE) $(PATCHES) dnsmasq.conf
 	@echo "building :" $(BINARY)
 	@mkdir -p $(@D)
-	@cp Dockerfile.cross $(OUTPUT_DIR)/Dockerfile
-	@cd $(OUTPUT_DIR) && sed -i- "s|__BASEIMAGE__|$(BASEIMAGE)|g" Dockerfile && rm Dockerfile-
+	@mkdir -p $(@D)/docker
+	@cp Dockerfile.cross $(OUTPUT_DIR)/docker/Dockerfile
+	@cd $(OUTPUT_DIR)/docker && sed -i- "s|__BASEIMAGE__|$(BASEIMAGE)|g" Dockerfile && rm Dockerfile-
+	@cd $(OUTPUT_DIR) && tar -xJf dnsmasq.tar.xz
+	@for patch in $(PATCHES); do patch -p0 -d $(OUTPUT_DIR)/$(DNSMASQ_VERSION) < $${patch}; done
+	@cp dnsmasq.conf $(OUTPUT_DIR)/docker
 
 ifeq ($(ARCH),amd64)
-	@cd $(OUTPUT_DIR) && sed -i- "/__CROSS_BUILD_COPY__/d" Dockerfile && rm Dockerfile-
+	@cd $(OUTPUT_DIR)/docker && \
+		sed -i- "/__CROSS_BUILD_COPY__/d" Dockerfile && rm Dockerfile-
 	@docker pull $(COMPILE_IMAGE)
-	@docker run --rm --sig-proxy=true     \
+	@docker run --rm --sig-proxy=true \
 		-v `pwd`/$(OUTPUT_DIR):/build \
 		-v `pwd`:/src                 \
 		$(COMPILE_IMAGE)              \
 		/bin/sh -c                    \
-		"apk update                                 \
+		"apk update                           \
 			&& apk add alpine-sdk xz libcap-dev \
-			&& tar -xJf /build/dnsmasq.tar.xz   \
-			&& cd $(DNSMASQ_VERSION)            \
+			&& cd /build/$(DNSMASQ_VERSION)     \
 			&& make -j                          \
-			&& cp src/dnsmasq /build" $(VERBOSE_OUTPUT)
+			&& cp src/dnsmasq /build/docker/dnsmasq" $(VERBOSE_OUTPUT)
 else
-	@cd $(OUTPUT_DIR)                                            \
+	@cd $(OUTPUT_DIR)/docker                                                 \
 		&& sed -i- "s|__ARCH__|$(QEMUARCH)|g" Dockerfile && rm Dockerfile-     \
 		&& sed -i- "s/__CROSS_BUILD_COPY__/COPY/g" Dockerfile && rm Dockerfile-
-	@cd $(OUTPUT_DIR) \
+	@cd $(OUTPUT_DIR)/docker \
 		&& curl -sSL $(MULTIARCH_RELEASE) | tar -xJ
-	@docker run --sig-proxy=true --rm            \
+	@docker run --sig-proxy=true --rm      \
 		--privileged $(MULTIARCH_CONTAINER)  \
 		--reset $(VERBOSE_OUTPUT)
 	@docker pull $(COMPILE_IMAGE)
-	@docker run --rm --sig-proxy=true            \
-		-v `pwd`/$(OUTPUT_DIR):/build        \
-		-v `pwd`:/src                        \
-		$(COMPILE_IMAGE)                     \
-		/bin/bash -c                         \
-		"tar -xJf /build/dnsmasq.tar.xz      \
-			&& cd $(DNSMASQ_VERSION)     \
-			&& CC=$(TRIPLE)-gcc make -j  \
-			&& cp src/dnsmasq /build" $(VERBOSE_OUTPUT)
+	@docker run --rm --sig-proxy=true \
+		-v `pwd`/$(OUTPUT_DIR):/build   \
+		-v `pwd`:/src                   \
+		$(COMPILE_IMAGE)                \
+		/bin/bash -c                    \
+		"cd /build/$(DNSMASQ_VERSION)   \
+			&& CC=$(TRIPLE)-gcc make -j   \
+			&& cp src/dnsmasq /build/docker/dnsmasq" $(VERBOSE_OUTPUT)
 endif
-	@cp dnsmasq.conf $(OUTPUT_DIR)
 
 $(DNSMASQ_ARCHIVE):
 	@mkdir -p $(@D)
@@ -150,7 +153,7 @@ containers: $(CONTAINER_STAMP)
 $(CONTAINER_STAMP): $(BINARY)
 	@echo "container:" $(REGISTRY)/$(IMAGE):$(VERSION)
 	@docker build --pull \
-		-q -t $(REGISTRY)/$(IMAGE):$(VERSION) $(OUTPUT_DIR) > $@
+		-q -t $(REGISTRY)/$(IMAGE):$(VERSION) $(OUTPUT_DIR)/docker > $@
 
 .PHONY: test
 test: containers


### PR DESCRIPTION
Patches in the patches/* are applied to the dnsmasq code in
lexigraphical order.