### PR TITLE
Better buckets for DNS probe latency

### DIFF
--- a/pkg/sidecar/dnsprobe.go
+++ b/pkg/sidecar/dnsprobe.go
@@ -95,7 +95,7 @@ func (p *dnsProbe) registerMetrics(options *Options) {
 		Subsystem: dnsProbeSubsystem,
 		Name:      p.Label + "_latency_ms",
 		Help:      "Latency of the DNS probe request " + p.Label,
-		Buckets:   prometheus.LinearBuckets(0, 10, 500),
+		Buckets:   prometheus.ExponentialBuckets(0.25, 2, 16), // from 0.25ms to 8 seconds
 	})
 	prometheus.MustRegister(p.latencyHistogram)
 


### PR DESCRIPTION
Use exponential-sized buckets and start at a much lower interval: instead of 500 buckets from 10ms to 500ms, use 16 buckets from 0.25ms to 8 seconds.  Much more precise data with 30 times less storage.

Fixes #149 

From an offline conversation with one of the Prometheus maintainers I am told that changing the bucket set will disrupt results for one averaging period, i.e. if you display `rate(...[5m])` then your chart will be wrong for the five minutes covering the change.  But with a minimum resolution of 10ms the old data is only useful when your DNS is a bit broken, so I think this one-time loss is OK.