### PR TITLE
Metric refactor

### DIFF
--- a/pkg/sidecar/dnsprobe.go
+++ b/pkg/sidecar/dnsprobe.go
@@ -93,7 +93,7 @@ func (p *dnsProbe) registerMetrics(options *Options) {
 	p.latencyHistogram = prometheus.NewHistogram(prometheus.HistogramOpts{
 		Namespace: options.PrometheusNamespace,
 		Subsystem: dnsProbeSubsystem,
-		Name:      p.Label + "_probe_latency_ms",
+		Name:      p.Label + "_probe_kubedns_latency_ms",
 		Help:      "Latency of the DNS probe request " + p.Label
 		Buckets:   prometheus.LinearBuckets(0, 10, 500),
 	})
@@ -102,7 +102,7 @@ func (p *dnsProbe) registerMetrics(options *Options) {
 	p.errorCount = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: options.PrometheusNamespace,
 		Subsystem: dnsProbeSubsystem,
-		Name:      p.Label + "_probe_errors",
+		Name:      p.Label + "_probe_kubedns_errors",
 		Help:      "Count of errors in name resolution of " + p.Label,
 	})
 	prometheus.MustRegister(p.errorCount)

--- a/pkg/sidecar/dnsprobe.go
+++ b/pkg/sidecar/dnsprobe.go
@@ -93,8 +93,8 @@ func (p *dnsProbe) registerMetrics(options *Options) {
 	p.latencyHistogram = prometheus.NewHistogram(prometheus.HistogramOpts{
 		Namespace: options.PrometheusNamespace,
 		Subsystem: dnsProbeSubsystem,
-		Name:      p.Label + "_latency_ms",
-		Help:      "Latency of the DNS probe request " + p.Label,
+		Name:      p.Label + "_probe_latency_ms",
+		Help:      "Latency of the DNS probe request " + p.Label
 		Buckets:   prometheus.LinearBuckets(0, 10, 500),
 	})
 	prometheus.MustRegister(p.latencyHistogram)
@@ -102,7 +102,7 @@ func (p *dnsProbe) registerMetrics(options *Options) {
 	p.errorCount = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: options.PrometheusNamespace,
 		Subsystem: dnsProbeSubsystem,
-		Name:      p.Label + "_errors",
+		Name:      p.Label + "_probe_errors",
 		Help:      "Count of errors in name resolution of " + p.Label,
 	})
 	prometheus.MustRegister(p.errorCount)

--- a/pkg/sidecar/dnsprobe.go
+++ b/pkg/sidecar/dnsprobe.go
@@ -94,7 +94,7 @@ func (p *dnsProbe) registerMetrics(options *Options) {
 		Namespace: options.PrometheusNamespace,
 		Subsystem: dnsProbeSubsystem,
 		Name:      p.Label + "_probe_kubedns_latency_ms",
-		Help:      "Latency of the DNS probe request " + p.Label
+		Help:      "Latency of the DNS probe request " + p.Label,
 		Buckets:   prometheus.LinearBuckets(0, 10, 500),
 	})
 	prometheus.MustRegister(p.latencyHistogram)

--- a/pkg/sidecar/metrics.go
+++ b/pkg/sidecar/metrics.go
@@ -27,7 +27,9 @@ import (
 )
 
 var (
-	gauges = make(map[dnsmasq.MetricName]prometheus.Gauge)
+	counters = make(map[dnsmasq.MetricName]prometheus.Counter)
+
+	countersCache = make(map[dnsmasq.MetricName]float64)
 
 	errorsCounter prometheus.Counter
 )
@@ -35,44 +37,44 @@ var (
 func defineDnsmasqMetrics(options *Options) {
 	const dnsmasqSubsystem = "dnsmasq"
 
-	gauges[dnsmasq.CacheHits] = prometheus.NewGauge(
-		prometheus.GaugeOpts{
+	counters[dnsmasq.CacheHits] = prometheus.NewCounter(
+		prometheus.CounterOpts{
 			Namespace: options.PrometheusNamespace,
 			Subsystem: dnsmasqSubsystem,
 			Name:      "hits",
 			Help:      "Number of DNS cache hits (from start of process)",
 		})
-	gauges[dnsmasq.CacheMisses] = prometheus.NewGauge(
-		prometheus.GaugeOpts{
+	counters[dnsmasq.CacheMisses] = prometheus.NewCounter(
+		prometheus.CounterOpts{
 			Namespace: options.PrometheusNamespace,
 			Subsystem: dnsmasqSubsystem,
 			Name:      "misses",
 			Help:      "Number of DNS cache misses (from start of process)",
 		})
-	gauges[dnsmasq.CacheEvictions] = prometheus.NewGauge(
-		prometheus.GaugeOpts{
+	counters[dnsmasq.CacheEvictions] = prometheus.NewCounter(
+		prometheus.CounterOpts{
 			Namespace: options.PrometheusNamespace,
 			Subsystem: dnsmasqSubsystem,
 			Name:      "evictions",
 			Help:      "Counter of DNS cache evictions (from start of process)",
 		})
-	gauges[dnsmasq.CacheInsertions] = prometheus.NewGauge(
-		prometheus.GaugeOpts{
+	counters[dnsmasq.CacheInsertions] = prometheus.NewCounter(
+		prometheus.CounterOpts{
 			Namespace: options.PrometheusNamespace,
 			Subsystem: dnsmasqSubsystem,
 			Name:      "insertions",
 			Help:      "Counter of DNS cache insertions (from start of process)",
 		})
-	gauges[dnsmasq.CacheSize] = prometheus.NewGauge(
-		prometheus.GaugeOpts{
+	counters[dnsmasq.CacheSize] = prometheus.NewCounter(
+		prometheus.CounterOpts{
 			Namespace: options.PrometheusNamespace,
 			Subsystem: dnsmasqSubsystem,
 			Name:      "max_size",
 			Help:      "Maximum size of the DNS cache",
 		})
 
-	for i := range gauges {
-		prometheus.MustRegister(gauges[i])
+	for i := range counters {
+		prometheus.MustRegister(counters[i])
 	}
 
 	errorsCounter = prometheus.NewCounter(

--- a/pkg/sidecar/server.go
+++ b/pkg/sidecar/server.go
@@ -74,6 +74,15 @@ func (s *server) runMetrics(options *Options) {
 
 func exportMetrics(metrics *dnsmasq.Metrics) {
 	for key := range *metrics {
-		gauges[key].Set(float64((*metrics)[key]))
+		// Retrieve the previous value of the metric and get the delta
+		// between the previous and current values. Add the delta to the
+		// previous to get the proper value. This is needed because the
+		// Counter API does not allow us to set the counter to a value.
+		previousValue := countersCache[key]
+		delta := float64((*metrics)[key]) - previousValue
+		newValue := previousValue + delta
+		// Update cache to new value.
+		countersCache[key] = newValue
+		counters[key].Add(newValue)
 	}
 }

--- a/pkg/sidecar/server_test.go
+++ b/pkg/sidecar/server_test.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sidecar
+
+import(
+	"testing"
+
+	"k8s.io/dns/pkg/dnsmasq"
+	"github.com/stretchr/testify/assert"
+)
+
+// initMetrics initializes dnsmasq.Metrics with values for testing.
+func initMetrics(metricsList []*dnsmasq.Metrics, values []int64) {
+	defineDnsmasqMetrics(&Options{PrometheusNamespace:"dnsmasq"})
+	for i := range metricsList {
+		metricsList[i] = &dnsmasq.Metrics{}
+		for j := range dnsmasq.AllMetrics {
+			metric := dnsmasq.AllMetrics[j]
+			// Avoids giving each metric the same value.
+			(*(metricsList[i]))[metric] = values[j] * int64(i+1)
+		}
+	}
+}
+
+// TestExportMetrics tests if our countersCache works as expected.
+func TestExportMetrics(t *testing.T) {
+	var m1, m2, m3 *dnsmasq.Metrics
+        l := []*dnsmasq.Metrics{m1, m2, m3}
+
+	testMetricValues := []int64{10, 20, 30, 40, 50}
+	initMetrics(l, testMetricValues)
+
+	for i := range l {
+		exportMetrics(l[i])
+		for j := range dnsmasq.AllMetrics {
+			assert.Equal(t, countersCache[dnsmasq.AllMetrics[j]], float64(testMetricValues[j] * int64(i+1)))
+		}
+	}
+}


### PR DESCRIPTION
Refactor to use Prometheus Counter instead of Gauge for metrics defined in pkg/sidecar/metrics.go
Also adds a new test server_test.go in sidecar package.