### PR TITLE
Fix travis: include vendor folder in build.sh

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -36,7 +36,13 @@ if [ $GOARCH == "amd64" ]; then
     export GOBIN="$GOPATH/bin/linux_amd64"
 fi
 
+# ./vendor/... is specified to include installing binary from vendor folder.
+# Since Go 1.9, vendor matching will no longer work with ./...
+# (https://golang.org/doc/go1.9#vendor-dotdotdot).
+# This is currently required because our travis CI is expecting the ginkgo
+# binary. We might get rid of this after removing that dependency.
 go install                                                         \
     -installsuffix "static"                                        \
     -ldflags "-X ${PKG}/pkg/version.VERSION=${VERSION}"            \
-    ./...
+    ./...                                                          \
+    ./vendor/...


### PR DESCRIPTION
Did a bit digging and found the CI build was broken after bumping to Go 1.9+ (https://github.com/kubernetes/dns/pull/193).

From Go 1.9 release notes, looks like command `go install ./...` will no longer matches package in vendor folder (https://golang.org/doc/go1.9#vendor-dotdotdot), which breaks our CI build because we are expecting `bin/amd64/ginkgo`.

This PR adds the vendor folder back for installing. Might not be the best choice but I think it at least works.

Fix https://github.com/kubernetes/dns/issues/203.