### PR TITLE
fix bug with delete externalName service

### DIFF
--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -408,7 +408,7 @@ func (kd *KubeDNS) addDNSUsingEndpoints(e *v1.Endpoints) error {
 	if err != nil {
 		return err
 	}
-	if svc == nil || v1.IsServiceIPSet(svc) {
+	if svc == nil || v1.IsServiceIPSet(svc) || svc.Spec.Type == v1.ServiceTypeExternalName {
 		// No headless service found corresponding to endpoints object.
 		return nil
 	}


### PR DESCRIPTION
On delete service from namespace kube-dns get event  EndpointAdd. 
Func addDNSUsingEndpoints generate RecordsForHeadlessService in cache to service type externalName. 
After this delete from a cache, it's deleted an empty record, but a record of Entries for externalName stuck forever.
Solution: don't generate the empty record for externalName