### PR TITLE
Delete docker pull from Makefiles

### DIFF
--- a/images/dnsmasq/Makefile
+++ b/images/dnsmasq/Makefile
@@ -75,6 +75,8 @@ BUILDSTAMP := $(subst :,_,$(subst /,_,$(REGISTRY))_$(IMAGE)_$(VERSION))
 CONTAINER_STAMP := .$(BUILDSTAMP)-container
 PUSH_STAMP := .$(BUILDSTAMP)-push
 
+DOCKER_PULL ?= 1
+
 ifeq ($(VERBOSE), 1)
 	VERBOSE_OUTPUT := >&1
 else
@@ -123,7 +125,9 @@ $(BINARY): Dockerfile.cross $(DNSMASQ_ARCHIVE) $(PATCHES) dnsmasq.conf
 ifeq ($(ARCH),amd64)
 	@cd $(OUTPUT_DIR)/docker && \
 		sed -i- "/__CROSS_BUILD_COPY__/d" Dockerfile && rm Dockerfile-
+ifeq (DOCKER_PULL, 1)
 	@docker pull $(COMPILE_IMAGE)
+endif
 	@docker run --rm --sig-proxy=true \
 		-v `pwd`/$(OUTPUT_DIR):/build \
 		-v `pwd`:/src                 \
@@ -143,7 +147,9 @@ else
 	@docker run --sig-proxy=true --rm      \
 		--privileged $(MULTIARCH_CONTAINER)  \
 		--reset $(VERBOSE_OUTPUT)
+ifeq (DOCKER_PULL, 1)
 	@docker pull $(COMPILE_IMAGE)
+endif
 	@docker run --rm --sig-proxy=true \
 		-v `pwd`/$(OUTPUT_DIR):/build   \
 		-v `pwd`:/src                   \
@@ -165,8 +171,13 @@ containers: $(CONTAINER_STAMP)
 
 $(CONTAINER_STAMP): $(BINARY)
 	@echo "container:" $(REGISTRY)/$(IMAGE):$(VERSION)
+ifeq (DOCKER_PULL, 1)
 	@docker build --pull \
 		-q -t $(REGISTRY)/$(IMAGE):$(VERSION) $(OUTPUT_DIR)/docker > $@
+else
+	@docker build \
+		-q -t $(REGISTRY)/$(IMAGE):$(VERSION) $(OUTPUT_DIR)/docker > $@
+endif
 
 .PHONY: test
 test: containers

--- a/rules.mk
+++ b/rules.mk
@@ -58,6 +58,8 @@ GO_BINARIES := $(addprefix bin/$(ARCH)/,$(ALL_BINARIES))
 CONTAINER_BUILDSTAMPS := $(foreach BINARY,$(CONTAINER_BINARIES),.$(BUILDSTAMP_NAME)-container)
 PUSH_BUILDSTAMPS := $(foreach BINARY,$(CONTAINER_BINARIES),.$(BUILDSTAMP_NAME)-push)
 
+DOCKER_PULL ?= 1
+
 ifeq ($(VERBOSE), 1)
 	DOCKER_BUILD_FLAGS :=
 	VERBOSE_OUTPUT := >&1
@@ -95,7 +97,9 @@ build: $(GO_BINARIES) images-build
 # Rule for all bin/$(ARCH)/bin/$(BINARY)
 $(GO_BINARIES): build-dirs
 	@echo "building : $@"
+ifeq (DOCKER_PULL, 1)
 	@docker pull $(BUILD_IMAGE)
+endif
 	@docker run                                                            \
 	    --rm                                                               \
 	    --sig-proxy=true                                                   \
@@ -135,7 +139,9 @@ $(foreach BINARY,$(CONTAINER_BINARIES),$(eval $(DOCKERFILE_RULE)))
 define CONTAINER_RULE
 .$(BUILDSTAMP_NAME)-container: bin/$(ARCH)/$(BINARY)
 	@echo "container: bin/$(ARCH)/$(BINARY) ($(CONTAINER_NAME))"
+ifeq (DOCKER_PULL, 1)
 	@docker pull $(BASEIMAGE)
+endif
 	@docker build					\
 		$(DOCKER_BUILD_FLAGS)			\
 		-t $(CONTAINER_NAME):$(VERSION)		\


### PR DESCRIPTION
That fixув building on closed clusters,
where for security reasons no internet connection are available
and needed images are unpacked to build machine

Docker will pull missing images self

For dnsmasq --pull useless because specific version of image
are set in file, so no new images will come.

Signed-off-by: Timofey Titovets <nefelim4ag@gmail.com>