### PR TITLE
Fix dnsmasq metric panic

### DIFF
--- a/pkg/sidecar/server.go
+++ b/pkg/sidecar/server.go
@@ -83,6 +83,11 @@ func exportMetrics(metrics *dnsmasq.Metrics) {
 		newValue := previousValue + delta
 		// Update cache to new value.
 		countersCache[key] = newValue
-		counters[key].Add(delta)
+		// Adding a negative delta will cause a panic.
+		if delta < 0 {
+			counters[key].Add(0)
+		} else {
+			counters[key].Add(delta)
+		}
 	}
 }


### PR DESCRIPTION
Fixes an issue that arises when the dnsmasq container is restarted on ConfigMap updated. In that case, the previous value of a metric is greater than the current value, which results in us adding a negative delta to the Prometheus Counter. This fix ensures that if the delta is negative, we add 0 to avoid a panic.

/assign @bowei 