### PR TITLE
Implement HasSynced() of skydns Backend interface

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -392,7 +392,7 @@
 		{
 			"ImportPath": "github.com/skynetservices/skydns/server",
 			"Comment": "2.5.3a-48-g2a758af",
-			"Rev": "2a758afb327924d46fb5424e7286bff3f94a36ea"
+			"Rev": "4ecf023198fec9ab999f92b7379010761ff053d3"
 		},
 		{
 			"ImportPath": "github.com/skynetservices/skydns/singleflight",

--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -569,6 +569,12 @@ func (kd *KubeDNS) newExternalNameService(service *v1.Service) {
 	kd.cache.SetEntry(service.Name, recordValue, fqdn, cachePath...)
 }
 
+// HasSynced returns true if the initial sync of services and endpoints
+// from the API server has completed
+func (kd *KubeDNS) HasSynced() bool {
+	return kd.endpointsController.HasSynced() && kd.serviceController.HasSynced()
+}
+
 // Records responds with DNS records that match the given name, in a format
 // understood by the skydns server. If "exact" is true, a single record
 // matching the given name is returned, otherwise all records stored under

--- a/vendor/github.com/skynetservices/skydns/server/backend.go
+++ b/vendor/github.com/skynetservices/skydns/server/backend.go
@@ -7,6 +7,7 @@ package server
 import "github.com/skynetservices/skydns/msg"
 
 type Backend interface {
+	HasSynced() bool
 	Records(name string, exact bool) ([]msg.Service, error)
 	ReverseRecord(name string) (*msg.Service, error)
 }
@@ -43,4 +44,9 @@ func (g FirstBackend) ReverseRecord(name string) (record *msg.Service, err error
 		}
 	}
 	return nil, lastError
+}
+
+func (g FirstBackend) HasSynced() bool {
+	// Stub implementation only to satisfy interface.
+	return true
 }

--- a/vendor/github.com/skynetservices/skydns/server/server.go
+++ b/vendor/github.com/skynetservices/skydns/server/server.go
@@ -144,7 +144,7 @@ func (s *server) ServeDNS(w dns.ResponseWriter, req *dns.Msg) {
 	q := req.Question[0]
 	name := strings.ToLower(q.Name)
 
-	if q.Qtype == dns.TypeANY {
+	if q.Qtype == dns.TypeANY || !s.backend.HasSynced() {
 		m.Authoritative = false
 		m.Rcode = dns.RcodeRefused
 		m.RecursionAvailable = false
@@ -200,7 +200,7 @@ func (s *server) ServeDNS(w dns.ResponseWriter, req *dns.Msg) {
 	}
 
 	for zone, ns := range *s.config.stub {
-		if strings.HasSuffix(name, "." + zone) || name == zone {
+		if strings.HasSuffix(name, "."+zone) || name == zone {
 			metrics.ReportRequestCount(req, metrics.Stub)
 
 			resp := s.ServeDNSStubForward(w, req, ns)
@@ -232,7 +232,7 @@ func (s *server) ServeDNS(w dns.ResponseWriter, req *dns.Msg) {
 		return
 	}
 
-	if q.Qclass != dns.ClassCHAOS && !strings.HasSuffix(name, "." +s.config.Domain) && name != s.config.Domain {
+	if q.Qclass != dns.ClassCHAOS && !strings.HasSuffix(name, "."+s.config.Domain) && name != s.config.Domain {
 		metrics.ReportRequestCount(req, metrics.Rec)
 
 		resp := s.ServeDNSForward(w, req)


### PR DESCRIPTION
This PR fixes #186.

We implement the HasSynced() interface that skydns defines. In the case that the endpoints and services have not been initally synced from the API server, skydns will now refuse the connection instead of returning NXDOMAIN.
