### PR TITLE
Fix external name not solving by reloading resolv.conf.

### DIFF
--- a/cmd/kube-dns/app/server.go
+++ b/cmd/kube-dns/app/server.go
@@ -71,7 +71,11 @@ func NewKubeDNSServerDefault(config *options.KubeDNSConfig) *KubeDNSServer {
 
 	default:
 		glog.V(0).Infof("ConfigMap and ConfigDir not configured, using values from command line flags")
-		configSync = dnsconfig.NewNopSync(&dnsconfig.Config{Federations: config.Federations, UpstreamNameservers: strings.Split(config.NameServers, ",")})
+		conf := dnsconfig.Config{Federations: config.Federations}
+		if len(config.NameServers) > 0 {
+			conf.UpstreamNameservers = strings.Split(config.NameServers, ",")
+		}
+		configSync = dnsconfig.NewNopSync(&conf)
 	}
 
 	return &KubeDNSServer{

--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -166,7 +166,7 @@ func (kd *KubeDNS) updateConfig(nextConfig *config.Config) {
 			if ip, port, err := util.ValidateNameserverIpAndPort(nameServer); err != nil {
 				glog.Errorf("Invalid nameserver %q: %v", nameServer, err)
 				if len(kd.SkyDNSConfig.Nameservers) == 0 {
-					// Fall back to resolv.conf on initialization failed.
+					// Fall back to resolv.conf on initialization failure.
 					kd.SkyDNSConfig.Nameservers = kd.loadDefaultNameserver()
 				}
 				return


### PR DESCRIPTION
Now skydns will be configured with resolv.conf when nameserver is empty.

Fixes#224 (https://github.com/kubernetes/dns/issues/224)

\assign @MrHohn 