### PR TITLE
fix pod hostname to be podname for dns srv records

### DIFF
--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -567,9 +567,18 @@ func (kd *KubeDNS) generateRecordsForHeadlessService(e *v1.Endpoints, svc *v1.Se
 }
 
 func getHostname(address *v1.EndpointAddress) (string, bool) {
+	// If hostname is specified, we use that
 	if len(address.Hostname) > 0 {
 		return address.Hostname, true
 	}
+
+	// If hostname is not specified, we use pod name
+	if address.TargetRef != nil {
+		if address.TargetRef.Kind == "Pod" {
+			return address.TargetRef.Name, true
+		}
+	}
+
 	return "", false
 }
 

--- a/pkg/dns/dns_test.go
+++ b/pkg/dns/dns_test.go
@@ -1016,3 +1016,32 @@ func getPodsFQDN(kd *KubeDNS, e *v1.Endpoints, podHostName string) string {
 func getSRVFQDN(kd *KubeDNS, s *v1.Service, portName string) string {
 	return fmt.Sprintf("_%s._tcp.%s.%s.svc.%s", portName, s.Name, s.Namespace, kd.domain)
 }
+
+func TestgetHostName_HostnameSpecfied_UseHostname(t *testing.T) {
+	endpointAddress := v1.EndpointAddress{
+		IP: "10.0.0.1",
+		TargetRef: &v1.ObjectReference{
+			Kind:      "Pod",
+			Name:      "foo-bar-zah",
+			Namespace: testNamespace,
+		},
+		Hostname: "foo",
+	}
+	hostname, found := getHostname(&endpointAddress)
+	assert.True(t, found)
+	assert.Equal(t, hostname, "foo")
+}
+
+func TestgetHostName_HostnameNotSpecfied_UsePodname(t *testing.T) {
+	endpointAddress := v1.EndpointAddress{
+		IP: "10.0.0.1",
+		TargetRef: &v1.ObjectReference{
+			Kind:      "Pod",
+			Name:      "foo-bar-zah",
+			Namespace: testNamespace,
+		},
+	}
+	hostname, found := getHostname(&endpointAddress)
+	assert.True(t, found)
+	assert.Equal(t, hostname, "foo-bar-zah")
+}


### PR DESCRIPTION
Fixes https://github.com/kubernetes/dns/issues/116 and https://github.com/kubernetes/kubernetes/issues/47992

Verified this works now 
```
/ # nslookup my-service.new-hire
Server:    10.254.208.255
Address 1: 10.254.208.255 kube-dns.kube-system.svc.cluster.local

Name:      my-service.new-hire
Address 1: 10.251.156.52 nginx-deployment-6fc8cd7954-q8p99.my-service.new-hire.svc.cluster.local
Address 2: 10.251.156.7 nginx-deployment-6fc8cd7954-w44gr.my-service.new-hire.svc.cluster.local
```