### PR TITLE
Fix DNS query to get metrics from Dnsmasq

### DIFF
--- a/pkg/dnsmasq/metrics.go
+++ b/pkg/dnsmasq/metrics.go
@@ -91,7 +91,7 @@ func (mc *metricsClient) GetMetrics() (ret *Metrics, err error) {
 func (mc *metricsClient) getSingleMetric(name string) (int64, error) {
 	msg := new(dns.Msg)
 	msg.Id = dns.Id()
-	msg.RecursionDesired = false
+	msg.RecursionDesired = true
 	msg.Question = make([]dns.Question, 1)
 	msg.Question[0] = dns.Question{
 		Name:   name,


### PR DESCRIPTION
This PR fixes the DNS queries to get metrics such as `hits.bind.`

Without this change, the sidecar doesn't report `kubedns_dnsmasq_hits` or similar metrics and it produces logs like:

```
W0910 16:07:40.684579   18427 server.go:64] Error getting metrics from dnsmasq: invalid number of Answer records for hits.bind.: 0
```

It seems that Dnsmasq requires the recursive flag to respond to these queries. Using dig confirms this. 

Working:
```
dig chaos txt hits.bind.
```
Not working:
```
dig +norecurse chaos txt hits.bind.
```
