### PR TITLE
Remove unused NOBODY/ARG_NOBODY arg from docker build

### DIFF
--- a/Dockerfile.sidecar
+++ b/Dockerfile.sidecar
@@ -18,5 +18,5 @@ MAINTAINER Bowei Du <bowei@google.com>
 
 ADD bin/ARG_ARCH/ARG_BIN /ARG_BIN
 
-USER nobody:ARG_NOBODY
+USER nobody:nobody
 ENTRYPOINT ["/ARG_BIN"]

--- a/rules.mk
+++ b/rules.mk
@@ -29,7 +29,6 @@ export VERSION
 SRC_DIRS := cmd pkg
 
 ALL_ARCH := amd64 arm arm64 ppc64le s390x
-NOBODY ?= nobody
 # Set default base image dynamically for each arch
 ifeq ($(ARCH),amd64)
     BASEIMAGE?=alpine:3.8
@@ -135,7 +134,6 @@ define DOCKERFILE_RULE
 	    -e 's|ARG_BIN|$(BINARY)|g' \
 	    -e 's|ARG_REGISTRY|$(REGISTRY)|g' \
 	    -e 's|ARG_FROM|$(BASEIMAGE)|g' \
-	    -e 's|ARG_NOBODY|$(NOBODY)|g' \
 	    -e 's|ARG_VERSION|$(VERSION)|g' \
 	    $$< > $$@
 .$(BUILDSTAMP_NAME)-container: .$(BINARY)-$(ARCH)-dockerfile


### PR DESCRIPTION
`NOBODY` and `ARG_NOBODY` were added in #31 because amd64 and the other architectures were using different base images, but its need was basically but removed in #127 when all architectures were converted to use alpine.

The names were also confusing (they apply to the group, not the user), so let's just remove them and hardcode the group in the Dockerfile again.