### PR TITLE
allow service name for stubDomains

### DIFF
--- a/cmd/dnsmasq-nanny/main.go
+++ b/cmd/dnsmasq-nanny/main.go
@@ -69,7 +69,7 @@ Any arguments given after "--" will be passed directly to dnsmasq itself.
 		opts.syncInterval,
 		"interval to check for configuration updates")
 	flag.StringVar(&opts.kubednsServer, "kubednsServer", opts.kubednsServer,
-		"kubedns server url for cluster.local dns records")
+		"local kubedns instance address for non-IP name resolution")
 	flag.Parse()
 }
 

--- a/cmd/dnsmasq-nanny/main.go
+++ b/cmd/dnsmasq-nanny/main.go
@@ -31,15 +31,17 @@ import (
 var (
 	opts = struct {
 		dnsmasq.RunNannyOpts
-		configDir    string
-		syncInterval time.Duration
+		configDir     string
+		syncInterval  time.Duration
+		kubednsServer string
 	}{
 		RunNannyOpts: dnsmasq.RunNannyOpts{
 			DnsmasqExec:     "/usr/sbin/dnsmasq",
 			RestartOnChange: false,
 		},
-		configDir:    "/etc/k8s/dns/dnsmasq-nanny",
-		syncInterval: 10 * time.Second,
+		configDir:     "/etc/k8s/dns/dnsmasq-nanny",
+		syncInterval:  10 * time.Second,
+		kubednsServer: "127.0.0.1:10053",
 	}
 )
 
@@ -66,6 +68,8 @@ Any arguments given after "--" will be passed directly to dnsmasq itself.
 	flag.DurationVar(&opts.syncInterval, "syncInterval",
 		opts.syncInterval,
 		"interval to check for configuration updates")
+	flag.StringVar(&opts.kubednsServer, "kubednsServer", opts.kubednsServer,
+		"kubedns server url for cluster.local dns records")
 	flag.Parse()
 }
 
@@ -75,5 +79,5 @@ func main() {
 
 	sync := config.NewFileSync(opts.configDir, opts.syncInterval)
 
-	dnsmasq.RunNanny(sync, opts.RunNannyOpts)
+	dnsmasq.RunNanny(sync, opts.RunNannyOpts, opts.kubednsServer)
 }

--- a/pkg/dnsmasq/nanny.go
+++ b/pkg/dnsmasq/nanny.go
@@ -20,6 +20,7 @@ import (
 	"bufio"
 	"fmt"
 	"io"
+	"net"
 	"os/exec"
 	"strings"
 
@@ -69,6 +70,11 @@ func (n *Nanny) Configure(args []string, config *config.Config) {
 
 	for domain, serverList := range config.StubDomains {
 		for _, server := range serverList {
+			if isIP := (net.ParseIP(server) != nil); !isIP {
+				if IPs, err := net.LookupIP(server); err == nil && len(IPs) > 0 {
+					server = IPs[0].String()
+				}
+			}
 			// dnsmasq port separator is '#' for some reason.
 			server = munge(server)
 			n.args = append(

--- a/pkg/dnsmasq/nanny.go
+++ b/pkg/dnsmasq/nanny.go
@@ -81,11 +81,15 @@ func (n *Nanny) Configure(args []string, config *config.Config, kubednsServer st
 			if isIP := (net.ParseIP(server) != nil); !isIP {
 				switch {
 				case strings.HasSuffix(server, "cluster.local"):
-					if IPs, err := resolver.LookupIPAddr(context.Background(), server); err == nil && len(IPs) > 0 {
+					if IPs, err := resolver.LookupIPAddr(context.Background(), server); err != nil {
+						glog.Errorf("Error looking up IP for %s: %v", server, err)
+					} else if len(IPs) > 0 {
 						server = IPs[0].String()
 					}
 				default:
-					if IPs, err := net.LookupIP(server); err == nil && len(IPs) > 0 {
+					if IPs, err := net.LookupIP(server); err != nil {
+						glog.Errorf("Error looking up IP for %s: %v", server, err)
+					} else if len(IPs) > 0 {
 						server = IPs[0].String()
 					}
 				}

--- a/pkg/dnsmasq/nanny_test.go
+++ b/pkg/dnsmasq/nanny_test.go
@@ -68,13 +68,16 @@ func TestNannyConfig(t *testing.T) {
 				StubDomains: map[string][]string{
 					"acme.local":   []string{"1.1.1.1"},
 					"widget.local": []string{"2.2.2.2:10053", "3.3.3.3"},
+					"google.local": []string{"google-public-dns-a.google.com"},
 				}},
 			e: []string{
 				"--abc",
 				"--server",
 				"--server",
 				"--server",
+				"--server",
 				"/acme.local/1.1.1.1",
+				"/google.local/8.8.8.8",
 				"/widget.local/2.2.2.2#10053",
 				"/widget.local/3.3.3.3",
 			},

--- a/pkg/dnsmasq/nanny_test.go
+++ b/pkg/dnsmasq/nanny_test.go
@@ -111,7 +111,7 @@ func TestNannyConfig(t *testing.T) {
 		},
 	} {
 		nanny := &Nanny{Exec: "dnsmasq"}
-		nanny.Configure([]string{"--abc"}, testCase.c)
+		nanny.Configure([]string{"--abc"}, testCase.c, "127.0.0.1:10053")
 		if testCase.sort {
 			sort.Sort(sort.StringSlice(nanny.args))
 		}
@@ -124,12 +124,14 @@ func TestNannyLifecycle(t *testing.T) {
 
 	const mockDnsmasq = "../../test/fixtures/mock-dnsmasq.sh"
 	var nanny *Nanny
+	kubednsServer := "127.0.0.1:10053"
 
 	// Exit with success.
 	nanny = &Nanny{Exec: mockDnsmasq}
 	nanny.Configure(
 		[]string{"--exitWithSuccess"},
-		&config.Config{})
+		&config.Config{},
+		kubednsServer)
 	gomega.Expect(nanny.Start()).To(gomega.Succeed())
 	gomega.Expect(<-nanny.ExitChannel).To(gomega.Succeed())
 
@@ -137,7 +139,8 @@ func TestNannyLifecycle(t *testing.T) {
 	nanny = &Nanny{Exec: mockDnsmasq}
 	nanny.Configure(
 		[]string{"--exitWithError"},
-		&config.Config{})
+		&config.Config{},
+		kubednsServer)
 	gomega.Expect(nanny.Start()).To(gomega.Succeed())
 	gomega.Expect(<-nanny.ExitChannel).NotTo(gomega.Succeed())
 
@@ -145,7 +148,8 @@ func TestNannyLifecycle(t *testing.T) {
 	nanny = &Nanny{Exec: mockDnsmasq}
 	nanny.Configure(
 		[]string{"--sleepThenError"},
-		&config.Config{})
+		&config.Config{},
+		kubednsServer)
 	gomega.Expect(nanny.Start()).To(gomega.Succeed())
 	gomega.Expect(<-nanny.ExitChannel).NotTo(gomega.Succeed())
 
@@ -153,7 +157,8 @@ func TestNannyLifecycle(t *testing.T) {
 	nanny = &Nanny{Exec: mockDnsmasq}
 	nanny.Configure(
 		[]string{"--runForever"},
-		&config.Config{})
+		&config.Config{},
+		kubednsServer)
 	gomega.Expect(nanny.Start()).To(gomega.Succeed())
 	time.Sleep(250 * time.Millisecond)
 	gomega.Expect(nanny.Kill()).To(gomega.Succeed())


### PR DESCRIPTION
Fixes #82 

it should work for not only kubernetes service name but also private dns record (e.g. dns.my.domain defined in GKE private dns) 