### PR TITLE
Create script to run node-local-dns cache without kubelet support

### DIFF
--- a/tools/node-cache/README.md
+++ b/tools/node-cache/README.md
@@ -1,0 +1,92 @@
+## Overview
+
+This example allows for use of the [node-local-dns
+cache](https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/dns/nodelocaldns),
+without requiring the kubelet `--cluster-dns` flag to be altered.  In
+particular, this means it can be used on GKE clusters.
+
+This is experimental, but feedback is welcome - please tag @justinsb.
+
+## Warning: Network policy
+
+If running with network policy, please see the [README for
+node-local-dns](https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/dns/nodelocaldns#network-policy-and-dns-connectivity);
+network policy will likely need to be configured for the node-local-dns agent.
+
+## Other caveats
+
+* If the node-local-dns agent crashes, DNS resolution will not function on that
+  node until it is restarted.
+
+* This configuration must be removed before installing the node-local-dns cache.
+
+## How it works
+
+Normally the node-local-dns agent:
+* uses an unused IP (typically `169.254.20.10`)
+* the kubelet `--cluster-dns` flag is used to specify that pods should use that
+  IP address (`169.254.20.10`) as their DNS server
+* CoreDNS runs as a daemonset on every node, configured to listen to the
+  internal IP (`169.254.20.10`)
+* CoreDNS caches results locally, but forwards uncached queries upstream to the
+  "real" kube-dns service
+* The node-local-dns agent configures IP tables rules to avoid conntrack / NAT
+
+In this mode, we instead intercept the existing kube-dns service IP a few
+things:
+* We configure the node-local-dns agent to intercept the kube-dns service IP
+* kubelet is already configured to send queries to that service, by default
+* We configure a second service to act as the "real" kube-dns service
+* When the node-local-dns agent configures the kube-dns service IP to avoid
+  conntrack/NAT, this takes precedence over the normal DNS service routing.
+
+## Installation
+
+A script is provided, simply run `./install.sh`
+
+## Removal
+
+Removal is more complicated that installation.  We can remove the daemonset, and as
+part of pod shutdown the node-local-dns cache should remove the IP interception
+rules.  However, if something goes wrong with the removal, the IP interception rules
+will remain in place, but the node-local-dns cache will not be running to serve
+the intercepted traffic, and DNS lookup will be broken on that node.  However,
+restarting the machine will remove the IP interception rules, so if this is done
+as part of a cluster update the system will self-heal.
+
+The procedure therefore is:
+
+* Run `./uninstall.sh`
+* Upgrade cluster
+* Remove uncached service using `kubectl delete service -n kube-system
+  kube-dns-uncached` (not critical, just for cleanup)
+
+## IP interception rules
+
+If you would like to verify that the IP interception rules are present or
+removed, the `list-iptables-rules.sh` will list the interception rules.
+
+For example, the output might look like:
+
+```
+---------------------------------------------------------------------------
+kube-proxy-gke-jsb-test-default-pool-751c2b6d-pnls
+---------------------------------------------------------------------------
+-P PREROUTING ACCEPT
+-P OUTPUT ACCEPT
+-A PREROUTING -d 10.23.240.10/32 -p udp -m udp --dport 53 -j NOTRACK
+-A PREROUTING -d 10.23.240.10/32 -p tcp -m tcp --dport 53 -j NOTRACK
+-A OUTPUT -s 10.23.240.10/32 -p udp -m udp --sport 53 -j NOTRACK
+-A OUTPUT -s 10.23.240.10/32 -p tcp -m tcp --sport 53 -j NOTRACK
+
+...
+
+```
+
+These rules are intercepting the ClusterIP for kube-dns (`10.23.240.10`), opting
+them out of conntracking and therefore of NAT.
+
+Finally, a script is included that can remove the interception iptables rules
+directly.  It can be run if `list-iptables-rules.sh` is showing any rules
+remaining after the daemonset has been removed.  It is
+`remove-iptables-rules.sh`

--- a/tools/node-cache/install.sh
+++ b/tools/node-cache/install.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -ex
+set -o pipefail
+
+# Create the underlying uncached service
+kubectl apply -f kube-dns-uncached.yaml
+
+# We will intercept the kube-dns service
+LOCAL_DNS=`kubectl get services -n kube-system kube-dns -o=jsonpath={.spec.clusterIP}`
+
+# And we will forward misses to the uncached service we created above
+UPSTREAM_DNS=`kubectl get services -n kube-system kube-dns-uncached -o=jsonpath={.spec.clusterIP}`
+
+# Assume the cluster DNS domain was not changed
+DNS_DOMAIN=cluster.local
+
+# nodelocaldns.yaml was sourced from k/k
+#
+# We should sync it occasionally with
+# wget https://raw.githubusercontent.com/kubernetes/kubernetes/master/cluster/addons/dns/nodelocaldns/nodelocaldns.yaml
+#
+cat nodelocaldns.yaml \
+  | sed -e s/addonmanager.kubernetes.io/#addonmanager.kubernetes.io/g \
+  | sed -e s@kubernetes.io/cluster-service@#kubernetes.io/cluster-service@g \
+  | sed -e 's@k8s-app: kube-dns@k8s-app: nodelocaldns@g' \
+  | sed s/__PILLAR__LOCAL__DNS__/${LOCAL_DNS}/g \
+  | sed s/__PILLAR__DNS__SERVER__/${UPSTREAM_DNS}/g \
+  | sed -e s/__PILLAR__DNS__DOMAIN__/${DNS_DOMAIN}/g \
+  | kubectl apply -f -

--- a/tools/node-cache/kube-dns-uncached.yaml
+++ b/tools/node-cache/kube-dns-uncached.yaml
@@ -1,0 +1,19 @@
+# This service is used to expose the kube-dns pods,
+# for use by the node-local-cache on cache-misses.
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-dns-uncached
+  namespace: kube-system
+spec:
+  ports:
+  - name: dns
+    port: 53
+    protocol: UDP
+    targetPort: 53
+  - name: dns-tcp
+    port: 53
+    protocol: TCP
+    targetPort: 53
+  selector:
+    k8s-app: kube-dns

--- a/tools/node-cache/list-iptables-rules.sh
+++ b/tools/node-cache/list-iptables-rules.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+echo "Listing iptables raw rules on all nodes (all kube-proxy pods)"
+
+for kp in `kubectl get pod -n kube-system -l component=kube-proxy -o custom-columns=:metadata.name --no-headers`; do
+  echo ""
+  echo "---------------------------------------------------------------------------"
+  echo $kp
+  echo "---------------------------------------------------------------------------"
+  kubectl exec -i -n kube-system $kp -- iptables -t raw --list-rules 
+done

--- a/tools/node-cache/nodelocaldns.yaml
+++ b/tools/node-cache/nodelocaldns.yaml
@@ -1,0 +1,144 @@
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: node-local-dns
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+---
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: node-local-dns
+  namespace: kube-system
+  labels:
+    addonmanager.kubernetes.io/mode: EnsureExists
+data:
+  Corefile: |
+    __PILLAR__DNS__DOMAIN__:53 {
+        errors
+        cache 30
+        reload
+        loop
+        bind __PILLAR__LOCAL__DNS__
+        forward . __PILLAR__DNS__SERVER__ {
+                force_tcp
+        }
+        prometheus :9253
+        health __PILLAR__LOCAL__DNS__:8080
+        }
+    in-addr.arpa:53 {
+        errors
+        cache 30
+        reload
+        loop
+        bind __PILLAR__LOCAL__DNS__
+        forward . __PILLAR__DNS__SERVER__ {
+                force_tcp
+        }
+        prometheus :9253
+        }
+    ip6.arpa:53 {
+        errors
+        cache 30
+        reload
+        loop
+        bind __PILLAR__LOCAL__DNS__
+        forward . __PILLAR__DNS__SERVER__ {
+                force_tcp
+        }
+        prometheus :9253
+        }
+    .:53 {
+        errors
+        cache 30
+        reload
+        loop
+        bind __PILLAR__LOCAL__DNS__
+        forward . /etc/resolv.conf {
+                force_tcp
+        }
+        prometheus :9253
+        }
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: node-local-dns
+  namespace: kube-system
+  labels:
+    k8s-app: kube-dns
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+spec:
+  selector:
+    matchLabels:
+      k8s-app: node-local-dns
+  template:
+    metadata:
+       labels:
+          k8s-app: node-local-dns
+    spec:
+      priorityClassName: system-node-critical
+      serviceAccountName: node-local-dns
+      hostNetwork: true
+      dnsPolicy: Default  # Don't use cluster DNS.
+      tolerations:
+      - key: "CriticalAddonsOnly"
+        operator: "Exists"
+      containers:
+      - name: node-cache
+        image: k8s.gcr.io/k8s-dns-node-cache:1.15.0
+        resources:
+          limits:
+            memory: 30Mi
+          requests:
+            cpu: 25m
+            memory: 5Mi
+        args: [ "-localip", "__PILLAR__LOCAL__DNS__", "-conf", "/etc/coredns/Corefile" ]
+        securityContext:
+          privileged: true
+        ports:
+        - containerPort: 53
+          name: dns
+          protocol: UDP
+        - containerPort: 53
+          name: dns-tcp
+          protocol: TCP
+        - containerPort: 9253
+          name: metrics
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            host: __PILLAR__LOCAL__DNS__
+            path: /health
+            port: 8080
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/coredns
+      volumes:
+        - name: config-volume
+          configMap:
+            name: node-local-dns
+            items:
+            - key: Corefile
+              path: Corefile

--- a/tools/node-cache/remove-iptables-rules.sh
+++ b/tools/node-cache/remove-iptables-rules.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e
+
+# We will intercept the kube-dns service
+LOCAL_DNS=`kubectl get services -n kube-system kube-dns -o=jsonpath={.spec.clusterIP}`
+
+if [[ -z "${LOCAL_DNS}" ]]; then
+  echo "Unable to find ClusterIP for kube-dns"
+  exit 1
+fi
+
+echo "Removing iptables raw rules for IP ${LOCAL_DNS} on all nodes (via kube-proxy pods)"
+
+for kp in `kubectl get pod -n kube-system -l component=kube-proxy -o custom-columns=:metadata.name --no-headers`; do
+  echo ""
+  echo "---------------------------------------------------------------------------"
+  echo $kp
+  echo "---------------------------------------------------------------------------"
+  kubectl exec -i -n kube-system $kp -- iptables -t raw -D PREROUTING -d ${LOCAL_DNS}/32 -p udp -m udp --dport 53 -j NOTRACK || true
+  kubectl exec -i -n kube-system $kp -- iptables -t raw -D PREROUTING -d ${LOCAL_DNS}/32 -p tcp -m tcp --dport 53 -j NOTRACK || true
+  kubectl exec -i -n kube-system $kp -- iptables -t raw -D OUTPUT -s 10.23.240.10/32 -p udp -m udp --sport 53 -j NOTRACK || true
+  kubectl exec -i -n kube-system $kp -- iptables -t raw -D OUTPUT -s 10.23.240.10/32 -p tcp -m tcp --sport 53 -j NOTRACK || true
+done

--- a/tools/node-cache/uninstall.sh
+++ b/tools/node-cache/uninstall.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -ex
+set -o pipefail
+
+cat nodelocaldns.yaml \
+  | kubectl delete -f -


### PR DESCRIPTION
This enables node-local-dns to be used experimentally prior to kubelet support.