### PR TITLE
Check error for SetDefaults()

### DIFF
--- a/cmd/kube-dns/app/server.go
+++ b/cmd/kube-dns/app/server.go
@@ -171,7 +171,9 @@ func (d *KubeDNSServer) startSkyDNSServer() {
 		Domain:  d.domain,
 		DnsAddr: fmt.Sprintf("%s:%d", d.dnsBindAddress, d.dnsPort),
 	}
-	server.SetDefaults(skydnsConfig)
+	if err := server.SetDefaults(skydnsConfig); err != nil {
+		glog.Fatalf("Failed to set defaults for Skydns server: %s", err)
+	}
 	s := server.New(d.kd, skydnsConfig)
 	if err := metrics.Metrics(); err != nil {
 		glog.Fatalf("Skydns metrics error: %s", err)


### PR DESCRIPTION
Ref https://github.com/kubernetes/dns/issues/283#issuecomment-451000345, we should check the error returned by `SetDefaults()`. Error in `SetDefaults()` might lead to a broken DNS server.

/assign @bowei 
cc @thebag25