### PR TITLE
Add retry logic when iptables checks fail

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -876,8 +876,10 @@
   analyzer-version = 1
   input-imports = [
     "github.com/coredns/coredns/coremain",
+    "github.com/coredns/coredns/plugin",
     "github.com/coredns/coredns/plugin/bind",
     "github.com/coredns/coredns/plugin/cache",
+    "github.com/coredns/coredns/plugin/debug",
     "github.com/coredns/coredns/plugin/errors",
     "github.com/coredns/coredns/plugin/forward",
     "github.com/coredns/coredns/plugin/health",
@@ -893,6 +895,7 @@
     "github.com/onsi/ginkgo",
     "github.com/onsi/gomega",
     "github.com/prometheus/client_golang/prometheus",
+    "github.com/prometheus/client_golang/prometheus/promhttp",
     "github.com/skynetservices/skydns/metrics",
     "github.com/skynetservices/skydns/msg",
     "github.com/skynetservices/skydns/server",

--- a/cmd/node-cache/main.go
+++ b/cmd/node-cache/main.go
@@ -191,15 +191,15 @@ func (c *cacheApp) runChecks() {
 			clog.Debugf("IP table rule (table %q, chain %q) already exists", rule.table, rule.chain)
 			continue
 		case err == nil:
-			clog.Infof("Added back nonexistent rule - %v", rule)
+			clog.Infof("Added back nodelocaldns rule - %v", rule)
 			continue
 		// if we got here, either iptables check failed or adding rule back failed.
 		case isLockedErr(err):
-			clog.Infof("Failed to check/add back rule %v, due to xtables lock in use, retrying in %v", rule, c.params.interval)
-			setupErrCount.WithLabelValues("iptables_lock_error").Inc()
+			clog.Infof("Error checking/adding iptables rule %v, due to xtables lock in use, retrying in %v", rule, c.params.interval)
+			setupErrCount.WithLabelValues("iptables_lock").Inc()
 		default:
-			clog.Errorf("Failed to add back non-existent rule %v - %s", rule, err)
-			setupErrCount.WithLabelValues("iptables_err").Inc()
+			clog.Errorf("Error adding iptables rule %v - %s", rule, err)
+			setupErrCount.WithLabelValues("iptables").Inc()
 		}
 	}
 
@@ -207,13 +207,13 @@ func (c *cacheApp) runChecks() {
 	if !exists {
 		if err != nil {
 			clog.Errorf("Failed to add back non-existent interface %s: %s", c.params.interfaceName, err)
-			setupErrCount.WithLabelValues("interface_add_err").Inc()
+			setupErrCount.WithLabelValues("interface_add").Inc()
 		}
 		clog.Infof("Added back nonexistent interface - %s", c.params.interfaceName)
 	}
 	if err != nil {
 		clog.Errorf("Failed to check dummy device %s - %s", c.params.interfaceName, err)
-		setupErrCount.WithLabelValues("interface_check_err").Inc()
+		setupErrCount.WithLabelValues("interface_check").Inc()
 	}
 }
 

--- a/cmd/node-cache/main.go
+++ b/cmd/node-cache/main.go
@@ -188,7 +188,7 @@ func (c *cacheApp) runChecks() {
 		switch {
 		case exists:
 			// debug messages can be printed by including "debug" plugin in coreFile.
-			clog.Debugf("IP table rule (table %q, chain %q) already exists", rule.table, rule.chain)
+			clog.Debugf("iptables rule %v for nodelocaldns already exists", rule)
 			continue
 		case err == nil:
 			clog.Infof("Added back nodelocaldns rule - %v", rule)
@@ -206,13 +206,13 @@ func (c *cacheApp) runChecks() {
 	exists, err := c.netifHandle.EnsureDummyDevice(c.params.interfaceName)
 	if !exists {
 		if err != nil {
-			clog.Errorf("Failed to add back non-existent interface %s: %s", c.params.interfaceName, err)
+			clog.Errorf("Failed to add non-existent interface %s: %s", c.params.interfaceName, err)
 			setupErrCount.WithLabelValues("interface_add").Inc()
 		}
-		clog.Infof("Added back nonexistent interface - %s", c.params.interfaceName)
+		clog.Infof("Added back interface - %s", c.params.interfaceName)
 	}
 	if err != nil {
-		clog.Errorf("Failed to check dummy device %s - %s", c.params.interfaceName, err)
+		clog.Errorf("Error checking dummy device %s - %s", c.params.interfaceName, err)
 		setupErrCount.WithLabelValues("interface_check").Inc()
 	}
 }

--- a/cmd/node-cache/main.go
+++ b/cmd/node-cache/main.go
@@ -161,7 +161,7 @@ func (c *cacheApp) parseAndValidateFlags() error {
 	}
 
 	flag.StringVar(&c.params.localIP, "localip", "", "ip address to bind dnscache to")
-	flag.StringVar(&c.params.interfaceName, "intfname", "nodelocaldns", "name of the interface to be created")
+	flag.StringVar(&c.params.interfaceName, "interfacename", "nodelocaldns", "name of the interface to be created")
 	flag.DurationVar(&c.params.interval, "syncinterval", 60, "interval(in seconds) to check for iptables rules")
 	flag.IntVar(&c.params.metricsPort, "metricsport", 9353, "port to serve nodecache setup metrics")
 	flag.Parse()

--- a/cmd/node-cache/metrics.go
+++ b/cmd/node-cache/metrics.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"net"
+	"net/http"
+
+	"github.com/coredns/coredns/plugin"
+	clog "github.com/coredns/coredns/plugin/pkg/log"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+var (
+	setupErrCount = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: plugin.Namespace,
+		Subsystem: "nodecache",
+		Name:      "setup_errors",
+		Help:      "The number of errors during periodic network setup for node-cache",
+	}, []string{"errortype"})
+)
+
+func initMetrics(ipport string) {
+	serveMetrics(ipport)
+	registerMetrics()
+}
+
+func registerMetrics() {
+	prometheus.MustRegister(setupErrCount)
+}
+
+func serveMetrics(ipport string) error {
+	ln, err := net.Listen("tcp", ipport)
+	if err != nil {
+		clog.Errorf("Failed to start metrics handler: %s", err)
+		return err
+	}
+
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.Handler())
+	srv := &http.Server{Handler: mux}
+	go func() {
+		srv.Serve(ln)
+	}()
+	return nil
+
+}

--- a/cmd/node-cache/metrics.go
+++ b/cmd/node-cache/metrics.go
@@ -20,7 +20,11 @@ var (
 )
 
 func initMetrics(ipport string) {
-	serveMetrics(ipport)
+	err := serveMetrics(ipport)
+	if err != nil {
+		clog.Errorf("Failed to start metrics handler: %s", err)
+		return
+	}
 	registerMetrics()
 }
 
@@ -31,7 +35,6 @@ func registerMetrics() {
 func serveMetrics(ipport string) error {
 	ln, err := net.Listen("tcp", ipport)
 	if err != nil {
-		clog.Errorf("Failed to start metrics handler: %s", err)
 		return err
 	}
 

--- a/cmd/node-cache/metrics.go
+++ b/cmd/node-cache/metrics.go
@@ -20,8 +20,7 @@ var (
 )
 
 func initMetrics(ipport string) {
-	err := serveMetrics(ipport)
-	if err != nil {
+	if err := serveMetrics(ipport); err != nil {
 		clog.Errorf("Failed to start metrics handler: %s", err)
 		return
 	}


### PR DESCRIPTION
Nodelocaldns runs background checks to ensure its custom iptables rules are present. On failure, the pod restarts.
When deployed in an environment with other pods also using iptables heavily, there can be xtables lock contention. Adding a retry logic instead of exiting on first failure. 
Fixes #292 