### PR TITLE
Rebase container images from alpine to distroless.

### DIFF
--- a/Dockerfile.node-cache
+++ b/Dockerfile.node-cache
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian:stable-slim
+FROM k8s.gcr.io/debian-base:v1.0.0
 RUN apt-get update && apt-get install -y \
     iproute2 \
     iptables \

--- a/rules.mk
+++ b/rules.mk
@@ -31,19 +31,19 @@ SRC_DIRS := cmd pkg
 ALL_ARCH := amd64 arm arm64 ppc64le s390x
 # Set default base image dynamically for each arch
 ifeq ($(ARCH),amd64)
-    BASEIMAGE?=alpine:3.8
+	BASEIMAGE?=k8s.gcr.io/debian-base:v1.0.0
 endif
 ifeq ($(ARCH),arm)
-    BASEIMAGE?=arm32v6/alpine:3.8
+	BASEIMAGE?=k8s.gcr.io/debian-base-arm:v1.0.0
 endif
 ifeq ($(ARCH),arm64)
-    BASEIMAGE?=arm64v8/alpine:3.8
+	BASEIMAGE?=k8s.gcr.io/debian-base-arm64:v1.0.0
 endif
 ifeq ($(ARCH),ppc64le)
-    BASEIMAGE?=ppc64le/alpine:3.8
+	BASEIMAGE?=k8s.gcr.io/debian-base-ppc64le:v1.0.0
 endif
 ifeq ($(ARCH),s390x)
-    BASEIMAGE?=s390x/alpine:3.8
+	BASEIMAGE?=k8s.gcr.io/debian-base-s390x:v1.0.0
 endif
 
 # These rules MUST be expanded at reference time (hence '=') as BINARY


### PR DESCRIPTION
Updated containers:kube-dns, sidecar
Context:[KEP: Rebase k8s images to distroless](https://github.com/kubernetes/enhancements/pull/900)
Test: 
1. `make images` can create the following images
staging-k8s.gcr.io/k8s-dns-sidecar-amd64 
staging-k8s.gcr.io/k8s-dns-node-cache-amd64
staging-k8s.gcr.io/k8s-dns-kube-dns-amd64
staging-k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64
staging-k8s.gcr.io/k8s-dns-dnsmasq-amd64 

2. `docker run -e <with required flags like service host/port> <Kube-DNS-IMAGE-ID>`
can successfully upstart a container.