### PR TITLE
Fix the compile image of dnsmasq.

### DIFF
--- a/images/dnsmasq/Makefile
+++ b/images/dnsmasq/Makefile
@@ -29,7 +29,7 @@ export DOCKER_CLI_EXPERIMENTAL=enabled
 
 ifeq ($(ARCH),amd64)
 	BASEIMAGE ?= k8s.gcr.io/debian-base:v1.0.0
-	COMPILE_IMAGE := k8s.gcr.io/debian-base:v1.0.0
+	COMPILE_IMAGE := alpine:3.8
 else ifeq ($(ARCH),arm)
 	BASEIMAGE ?= k8s.gcr.io/debian-base-arm:v1.0.0
 	TRIPLE    ?= arm-linux-gnueabihf


### PR DESCRIPTION
In my previous [PR](https://github.com/kubernetes/dns/commit/9b9f8f21c437e455c9e4f0a31a4101e6c4e9d7bd#diff-19ad075a08a3805259532e36f128f677), the dnsmasq compile image (not base) is mistakenly configured to debian-base. However, the dnsmasq Makefile specifies the [alpine dependencies](https://github.com/kubernetes/dns/blob/master/images/dnsmasq/Makefile#L139) on installing the alpine-sdk package, so the dnsmasq image can't be built successfully.

This PR reverts the compile image change (which is not covered in the rebasing distroless image effort)   