### PR TITLE
Node cache: Make metrics listen address configurable

### DIFF
--- a/cmd/node-cache/main.go
+++ b/cmd/node-cache/main.go
@@ -30,12 +30,12 @@ import (
 
 // configParams lists the configuration options that can be provided to dns-cache
 type configParams struct {
-	localIP       string        // ip address for the local cache agent to listen for dns requests
-	localPort     string        // port to listen for dns requests
-	metricsPort   int           // port to serve node-cache metrics
-	interfaceName string        // Name of the interface to be created
-	interval      time.Duration // specifies how often to run iptables rules check
-	exitChan      chan bool     // Channel to terminate background goroutines
+	localIP              string        // ip address for the local cache agent to listen for dns requests
+	localPort            string        // port to listen for dns requests
+	metricsListenAddress string        // address to serve metrics on
+	interfaceName        string        // Name of the interface to be created
+	interval             time.Duration // specifies how often to run iptables rules check
+	exitChan             chan bool     // Channel to terminate background goroutines
 }
 
 type iptablesRule struct {
@@ -75,7 +75,7 @@ func (c *cacheApp) Init() {
 		cache.teardownNetworking()
 		clog.Fatalf("Failed to setup - %s, Exiting", err)
 	}
-	initMetrics(net.JoinHostPort(c.params.localIP, strconv.Itoa(c.params.metricsPort)))
+	initMetrics(c.params.metricsListenAddress)
 }
 
 func init() {
@@ -163,7 +163,7 @@ func (c *cacheApp) parseAndValidateFlags() error {
 	flag.StringVar(&c.params.localIP, "localip", "", "ip address to bind dnscache to")
 	flag.StringVar(&c.params.interfaceName, "interfacename", "nodelocaldns", "name of the interface to be created")
 	flag.DurationVar(&c.params.interval, "syncinterval", 60, "interval(in seconds) to check for iptables rules")
-	flag.IntVar(&c.params.metricsPort, "metricsport", 9353, "port to serve nodecache setup metrics")
+	flag.StringVar(&c.params.metricsListenAddress, "metrics-listen-address", "0.0.0.0:9353", "address to serve metrics on")
 	flag.Parse()
 
 	if net.ParseIP(c.params.localIP) == nil {


### PR DESCRIPTION
This PR makes the metrics listen address, including interface, for the node cache configurable. This is required in order to actually be able to scrape those metrics, because the local IP is par design only reachable from the node the addon runs on.

The default of `127.0.0.2:9353` was chosen deliberately, as we can be very sure nothing will listen there already.

/assign @prameshj 