### PR TITLE
Change dnsmasq compile-image to debian.

### DIFF
--- a/images/dnsmasq/Makefile
+++ b/images/dnsmasq/Makefile
@@ -29,7 +29,7 @@ export DOCKER_CLI_EXPERIMENTAL=enabled
 
 ifeq ($(ARCH),amd64)
 	BASEIMAGE ?= k8s.gcr.io/debian-base:v1.0.0
-	COMPILE_IMAGE := alpine:3.8
+	COMPILE_IMAGE := k8s.gcr.io/debian-base:v1.0.0
 else ifeq ($(ARCH),arm)
 	BASEIMAGE ?= k8s.gcr.io/debian-base-arm:v1.0.0
 	TRIPLE    ?= arm-linux-gnueabihf
@@ -136,8 +136,8 @@ ifeq ($(ARCH),amd64)
 		-v `pwd`:/src                 \
 		$(COMPILE_IMAGE)              \
 		/bin/sh -c                    \
-		"apk update                           \
-			&& apk add alpine-sdk xz libcap-dev \
+		"apt-get update                           \
+			&& apt-get -y install build-essential libcap-dev \
 			&& cd /build/$(DNSMASQ_VERSION)     \
 			&& make -j                          \
 			&& cp src/dnsmasq /build/docker/dnsmasq" $(VERBOSE_OUTPUT)


### PR DESCRIPTION
After the base-image change to debian, dnsmasq built with alpine libraries was running in a debian environment and
crashing due to failed dependencies. This change fixes the issue https://github.com/kubernetes/dns/issues/308

Built gcr.io/pavithrar-k8s-dev/k8s-dns-dnsmasq-nanny:1.15.3-dirty and verified that it works.