### PR TITLE
Fix hardcoded base image for node-cache kubernetes/dns#314

### DIFF
--- a/Dockerfile.node-cache
+++ b/Dockerfile.node-cache
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM k8s.gcr.io/debian-base:v1.0.0
+FROM ARG_FROM
 RUN apt-get update && apt-get install -y \
     iproute2 \
     iptables \


### PR DESCRIPTION
This fixes the bug mentioned in kubernetes/dns#314 which in causing multi-arch builds to publish amd64 images.