### PR TITLE
Skip conntrack for DNS requests to node-cache from host

### DIFF
--- a/cmd/node-cache/main.go
+++ b/cmd/node-cache/main.go
@@ -112,6 +112,11 @@ func (c *cacheApp) initIptables() {
 				"--sport", c.params.localPort, "-j", "ACCEPT"}},
 			{utiliptables.TableFilter, utiliptables.ChainOutput, []string{"-p", "udp", "-s", localIP,
 				"--sport", c.params.localPort, "-j", "ACCEPT"}},
+			// Skip connection tracking for requests to nodelocalDNS that are locally generated, example - by hostNetwork pods
+			{utiliptables.Table("raw"), utiliptables.ChainOutput, []string{"-p", "tcp", "-d", localIP,
+				"--dport", c.params.localPort, "-j", "NOTRACK"}},
+			{utiliptables.Table("raw"), utiliptables.ChainOutput, []string{"-p", "udp", "-d", localIP,
+				"--dport", c.params.localPort, "-j", "NOTRACK"}},
 		}...)
 	}
 	c.iptables = newIPTables()


### PR DESCRIPTION
For pods running on hostNetWithClusterFirst mode, the DNS requests to nodelocaldns will be generated from host network, so they skip
the PREROUTING chain. Currently, NOTRACK rules are added in the raw PREROUTING chain. These request packets will be subject to NAT rules added by
kube-proxy if nodelocaldns uses a service ClusterIP as a listenIP.

This PR adds the NOTRACK rules to raw OUTPUT table so that locally generated requests also skip CONNTRACK.

Fixes issue https://github.com/kubernetes/dns/issues/318

I was able to verify that this works, the reporter of the issue was able to, as well.
cc @axot