### PR TITLE
Support kube-dns stubdomain config in node-cache

### DIFF
--- a/cmd/node-cache/app/cache_app.go
+++ b/cmd/node-cache/app/cache_app.go
@@ -73,6 +73,8 @@ func (c *CacheApp) Init() {
 		clog.Fatalf("Failed to setup - %s, Exiting", err)
 	}
 	initMetrics(c.params.MetricsListenAddress)
+	// Write the config file from template.
+	// this is required in case there is no kube-dns configmap specified.
 	c.updateCorefile(&config.Config{})
 	c.initKubeDNSConfigSync()
 }

--- a/cmd/node-cache/app/cache_app_test.go
+++ b/cmd/node-cache/app/cache_app_test.go
@@ -1,0 +1,1 @@
+package app

--- a/cmd/node-cache/app/cache_app_test.go
+++ b/cmd/node-cache/app/cache_app_test.go
@@ -1,1 +1,162 @@
 package app
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"k8s.io/dns/pkg/dns/config"
+)
+
+const (
+	templateCoreFileContents = `
+	cluster.local:53 {
+        errors
+        cache {
+                success 9984 30
+                denial 9984 5
+        }
+        reload
+        loop
+        bind __PILLAR__LOCAL__DNS__
+        forward . __PILLAR__CLUSTER__DNS__ {
+                force_tcp
+        }
+        prometheus :9253
+        health __PILLAR__LOCAL__DNS__:8080
+        }
+    .:53 {
+        errors
+        cache 30
+        reload
+        loop
+        bind __PILLAR__LOCAL__DNS__
+        forward . __PILLAR__UPSTREAM__SERVERS__ {
+                force_tcp
+        }
+        prometheus :9253
+        }
+	`
+	templateCoreFileName   = "testCoreFile.base"
+	coreFileName           = "testCoreFile"
+	cmDirName              = "testKubeDNSDir"
+	stubDomainFileName     = "stubDomains"
+	upstreamServerFileName = "upstreamNameservers"
+	UpstreamClusterDNS     = "test-svc"
+)
+
+func updateStubDomainsAndUpstreamServers(t *testing.T, p *ConfigParams, c *config.Config) string {
+	if stubDomainBlob, err := json.Marshal(c.StubDomains); err != nil {
+		t.Errorf("Failed to marshal stubdomains info, err %v", err)
+	} else {
+		err = ioutil.WriteFile(filepath.Join(p.KubednsCMPath, stubDomainFileName), stubDomainBlob, os.ModePerm)
+		if err != nil {
+			t.Errorf("Failed to write stubDomains file - %s, err %v", stubDomainFileName, err)
+		}
+	}
+
+	if upstreamBlob, err := json.Marshal(c.UpstreamNameservers); err != nil {
+		t.Errorf("Failed to marshal upstream nameservers info, err %v", err)
+	} else {
+		err = ioutil.WriteFile(filepath.Join(p.KubednsCMPath, upstreamServerFileName), upstreamBlob, os.ModePerm)
+		if err != nil {
+			t.Errorf("Failed to write stubDomains file - %s, err %v", upstreamServerFileName, err)
+		}
+	}
+	return ""
+}
+
+func createBaseFiles(t *testing.T, p *ConfigParams) {
+	err := ioutil.WriteFile(p.BaseCoreFile, []byte(templateCoreFileContents), os.ModePerm)
+	if err != nil {
+		t.Fatalf("Failed to write template config file - %v", err)
+	}
+	if err = os.Mkdir(p.KubednsCMPath, os.ModePerm); err != nil {
+		t.Fatalf("Failed to create KubeDNS configmap dir - %v", err)
+	}
+}
+
+func compareFileContents(filename, contents string, t *testing.T) (string, int) {
+	out, err := ioutil.ReadFile(filename)
+	if err != nil {
+		t.Errorf("Failed to read file %s , err %v", filename, err)
+		return "", -1
+	}
+	return string(out), strings.Compare(string(out), contents)
+}
+
+func stubDomainsEqual(str1, str2 string, t *testing.T) bool {
+	// Double newline separates one stubdomain block from next
+	blocks1 := strings.Split(str1, "\n\n")
+	blocks2 := strings.Split(str2, "\n\n")
+	if len(blocks1) != len(blocks2) {
+		return false
+	}
+	sort.Strings(blocks1)
+	sort.Strings(blocks2)
+	for i, v := range blocks1 {
+		if v != blocks2[i] {
+			// Printing raw bytes is more useful to identify the inequality
+			t.Errorf("Stubdomains not equal - %+v and %+v", []byte(v), []byte(blocks2[i]))
+			return false
+		}
+	}
+	return true
+}
+
+func TestUpdateCoreFile(t *testing.T) {
+	baseDir, err := ioutil.TempDir("", "dnstest")
+	if err != nil {
+		t.Fatalf("Failed to obtain temp directory for testing, err %v", err)
+	}
+	envName := strings.ToUpper(strings.Replace(UpstreamClusterDNS, "-", "_", -1)) + "_SERVICE_HOST"
+	os.Setenv(envName, "9.10.11.12")
+	defer func() { os.RemoveAll(baseDir) }()
+	c, err := NewCacheApp(&ConfigParams{LocalIPStr: "169.254.20.10",
+		LocalPort:       "53",
+		BaseCoreFile:    filepath.Join(baseDir, templateCoreFileName),
+		CoreFile:        filepath.Join(baseDir, coreFileName),
+		KubednsCMPath:   filepath.Join(baseDir, cmDirName),
+		UpstreamSvcName: UpstreamClusterDNS,
+		SetupIptables:   false,
+	})
+	if err != nil {
+		t.Fatalf("Failed to obtain CacheApp instance, err %v", err)
+	}
+	createBaseFiles(t, c.params)
+	c.initKubeDNSConfigSync()
+	r := strings.NewReplacer("__PILLAR__LOCAL__DNS__", c.params.LocalIPStr, "__PILLAR__CLUSTER__DNS__", "9.10.11.12",
+		"__PILLAR__UPSTREAM__SERVERS__", "/etc/resolv.conf")
+	expectedContents := r.Replace(templateCoreFileContents)
+	if out, diff := compareFileContents(c.params.CoreFile, expectedContents, t); diff != 0 {
+		t.Errorf("Expected contents '%s', Got '%s'", expectedContents, out)
+	}
+	customConfig := &config.Config{StubDomains: map[string][]string{
+		"acme.local":   {"1.1.1.1"},
+		"google.local": {"google-public-dns-a.google.com"},
+		"widget.local": {"2.2.2.2:10053", "3.3.3.3"},
+	},
+		UpstreamNameservers: []string{"2.2.2.2:10053", "3.3.3.3"},
+	}
+	updateStubDomainsAndUpstreamServers(t, c.params, customConfig)
+	expectedContents = strings.Replace(expectedContents, "/etc/resolv.conf", strings.Join(customConfig.UpstreamNameservers, " "), -1)
+	expectedStubStr := getStubDomainStr(customConfig.StubDomains, &stubDomainInfo{Port: c.params.LocalPort, CacheTTL: defaultTTL, LocalIP: c.params.LocalIPStr})
+
+	time.Sleep(10 * time.Second)
+	out, _ := compareFileContents(c.params.CoreFile, expectedContents, t)
+	if !strings.Contains(out, expectedContents) {
+		t.Fatalf("Could not find contents '%s' in CoreFile '%s'", expectedContents, out)
+	}
+	// The entire file cannot be compared because the stubDomains block
+	// will be in a different order as they are generated by iterating over
+	// a map. They will be converted  to a list and compared individually.
+	stubStr := strings.TrimPrefix(out, expectedContents)
+	if !stubDomainsEqual(strings.TrimSpace(stubStr), strings.TrimSpace(expectedStubStr), t) {
+		t.Fail()
+	}
+}

--- a/cmd/node-cache/app/cache_app_test.go
+++ b/cmd/node-cache/app/cache_app_test.go
@@ -54,8 +54,7 @@ func updateStubDomainsAndUpstreamServers(t *testing.T, p *ConfigParams, c *confi
 	if stubDomainBlob, err := json.Marshal(c.StubDomains); err != nil {
 		t.Errorf("Failed to marshal stubdomains info, err %v", err)
 	} else {
-		err = ioutil.WriteFile(filepath.Join(p.KubednsCMPath, stubDomainFileName), stubDomainBlob, os.ModePerm)
-		if err != nil {
+		if err := ioutil.WriteFile(filepath.Join(p.KubednsCMPath, stubDomainFileName), stubDomainBlob, os.ModePerm); err != nil {
 			t.Errorf("Failed to write stubDomains file - %s, err %v", stubDomainFileName, err)
 		}
 	}
@@ -63,8 +62,7 @@ func updateStubDomainsAndUpstreamServers(t *testing.T, p *ConfigParams, c *confi
 	if upstreamBlob, err := json.Marshal(c.UpstreamNameservers); err != nil {
 		t.Errorf("Failed to marshal upstream nameservers info, err %v", err)
 	} else {
-		err = ioutil.WriteFile(filepath.Join(p.KubednsCMPath, upstreamServerFileName), upstreamBlob, os.ModePerm)
-		if err != nil {
+		if err = ioutil.WriteFile(filepath.Join(p.KubednsCMPath, upstreamServerFileName), upstreamBlob, os.ModePerm); err != nil {
 			t.Errorf("Failed to write stubDomains file - %s, err %v", upstreamServerFileName, err)
 		}
 	}
@@ -72,11 +70,10 @@ func updateStubDomainsAndUpstreamServers(t *testing.T, p *ConfigParams, c *confi
 }
 
 func createBaseFiles(t *testing.T, p *ConfigParams) {
-	err := ioutil.WriteFile(p.BaseCoreFile, []byte(templateCoreFileContents), os.ModePerm)
-	if err != nil {
+	if err := ioutil.WriteFile(p.BaseCoreFile, []byte(templateCoreFileContents), os.ModePerm); err != nil {
 		t.Fatalf("Failed to write template config file - %v", err)
 	}
-	if err = os.Mkdir(p.KubednsCMPath, os.ModePerm); err != nil {
+	if err := os.Mkdir(p.KubednsCMPath, os.ModePerm); err != nil {
 		t.Fatalf("Failed to create KubeDNS configmap dir - %v", err)
 	}
 }

--- a/cmd/node-cache/app/configmap.go
+++ b/cmd/node-cache/app/configmap.go
@@ -70,13 +70,12 @@ func (c *CacheApp) updateCorefile(dnsConfig *config.Config) {
 	newConfig := bytes.Buffer{}
 	newConfig.WriteString(string(baseConfig))
 	newConfig.WriteString(stubDomainStr)
-	err = ioutil.WriteFile(c.params.CoreFile, newConfig.Bytes(), 0666)
-	if err != nil {
+	if err := ioutil.WriteFile(c.params.CoreFile, newConfig.Bytes(), 0666); err != nil {
 		clog.Errorf("Failed to write config file %s - err %v", c.params.CoreFile, err)
 		return
 	}
 	clog.Infof("Updated Corefile with %d custom stubdomains and upstream servers %s", len(dnsConfig.StubDomains), upstreamServers)
-	clog.Debugf("Using config file:\n%s", newConfig.String())
+	clog.Infof("Using config file:\n%s", newConfig.String())
 }
 
 func (c *CacheApp) syncKubeDNSConfig(syncChan <-chan *config.Config) {

--- a/cmd/node-cache/app/configmap.go
+++ b/cmd/node-cache/app/configmap.go
@@ -1,0 +1,103 @@
+package app
+
+import (
+	"bytes"
+	"io/ioutil"
+	"strings"
+	"text/template"
+
+	clog "github.com/coredns/coredns/plugin/pkg/log"
+	"k8s.io/dns/pkg/dns/config"
+)
+
+const (
+	stubDomainBlock = `
+{{.DomainName}}:{{.Port}} {
+    errors
+    cache {{.CacheTTL}}
+    bind {{.LocalIP}}
+    forward . {{.UpstreamServers}} {
+      force_tcp
+    }
+}
+`  // cache TTL is 30s by default
+	defaultTTL = 30
+)
+
+// stubDomainInfo contains all the parameters needed to compute
+// a stubDomain block in the Corefile.
+type stubDomainInfo struct {
+	DomainName      string
+	LocalIP         string
+	Port            string
+	CacheTTL        int
+	UpstreamServers string
+}
+
+func getStubDomainStr(stubDomainMap map[string][]string, info *stubDomainInfo) string {
+	var tpl bytes.Buffer
+	for domainName, servers := range stubDomainMap {
+		tmpl, err := template.New("stubDomainBlock").Parse(stubDomainBlock)
+		if err != nil {
+			clog.Errorf("Failed to create stubDomain template, err : %v", err)
+			continue
+		}
+		info.DomainName = domainName
+		info.UpstreamServers = strings.Join(servers, " ")
+		tmpl.Execute(&tpl, *info)
+	}
+	return tpl.String()
+}
+
+func (c *CacheApp) updateCorefile(dnsConfig *config.Config) {
+	// construct part of the Corefile
+	baseConfig, err := ioutil.ReadFile(c.params.BaseCoreFile)
+	if err != nil {
+		clog.Errorf("Failed to read node-cache coreFile %s - %v", c.params.BaseCoreFile, err)
+		return
+	}
+	stubDomainStr := getStubDomainStr(dnsConfig.StubDomains, &stubDomainInfo{Port: c.params.LocalPort, CacheTTL: defaultTTL, LocalIP: c.params.LocalIPStr})
+	upstreamServers := strings.Join(dnsConfig.UpstreamNameservers, " ")
+	if upstreamServers == "" {
+		// forward plugin supports both nameservers as well as resolv.conf
+		// use resolv.conf by default.
+		upstreamServers = "/etc/resolv.conf"
+	}
+	baseConfig = bytes.Replace(baseConfig, []byte("__PILLAR__UPSTREAM__SERVERS__"), []byte(upstreamServers), -1)
+	baseConfig = bytes.Replace(baseConfig, []byte("__PILLAR__CLUSTER__DNS__"), []byte(c.clusterDNSIP.String()), -1)
+	baseConfig = bytes.Replace(baseConfig, []byte("__PILLAR__LOCAL__DNS__"), []byte(c.params.LocalIPStr), -1)
+
+	newConfig := bytes.Buffer{}
+	newConfig.WriteString(string(baseConfig))
+	newConfig.WriteString(stubDomainStr)
+	err = ioutil.WriteFile(c.params.CoreFile, newConfig.Bytes(), 0666)
+	if err != nil {
+		clog.Errorf("Failed to write config file %s - err %v", c.params.CoreFile, err)
+		return
+	}
+	clog.Infof("Updated Corefile with %d custom stubdomains and upstream servers %s", len(dnsConfig.StubDomains), upstreamServers)
+	clog.Debugf("Using config file:\n%s", newConfig.String())
+}
+
+func (c *CacheApp) syncKubeDNSConfig(syncChan <-chan *config.Config) {
+	for {
+		nextConfig := <-syncChan
+		c.updateCorefile(nextConfig)
+	}
+}
+
+func (c *CacheApp) initKubeDNSConfigSync() {
+	if c.params.KubednsCMPath == "" {
+		clog.Infof("No kube-dns configmap path specified, exiting sync")
+		return
+	}
+	c.kubednsConfig.ConfigDir = c.params.KubednsCMPath
+	configSync := config.NewFileSync(c.kubednsConfig.ConfigDir, c.kubednsConfig.ConfigPeriod)
+	initialConfig, err := configSync.Once()
+	if err != nil {
+		clog.Errorf("Failed to sync kube-dns config directory %s, err: %v", c.params.KubednsCMPath, err)
+		return
+	}
+	c.updateCorefile(initialConfig)
+	go c.syncKubeDNSConfig(configSync.Periodic())
+}

--- a/cmd/node-cache/app/metrics.go
+++ b/cmd/node-cache/app/metrics.go
@@ -1,4 +1,4 @@
-package main
+package app
 
 import (
 	"net"

--- a/cmd/node-cache/main.go
+++ b/cmd/node-cache/main.go
@@ -3,265 +3,88 @@ package main
 import (
 	"fmt"
 
+	"k8s.io/dns/cmd/node-cache/app"
+
 	"flag"
 	"net"
 	"os"
 	"strconv"
 	"strings"
-	"time"
 
-	"github.com/coredns/coredns/coremain"
+	clog "github.com/coredns/coredns/plugin/pkg/log"
+	// blank imports to make sure the plugin code is pulled in from vendor when building node-cache image
 	_ "github.com/coredns/coredns/plugin/bind"
 	_ "github.com/coredns/coredns/plugin/cache"
+	_ "github.com/coredns/coredns/plugin/debug"
 	_ "github.com/coredns/coredns/plugin/errors"
 	_ "github.com/coredns/coredns/plugin/forward"
 	_ "github.com/coredns/coredns/plugin/health"
 	_ "github.com/coredns/coredns/plugin/log"
 	_ "github.com/coredns/coredns/plugin/loop"
 	_ "github.com/coredns/coredns/plugin/metrics"
-	clog "github.com/coredns/coredns/plugin/pkg/log"
 	_ "github.com/coredns/coredns/plugin/reload"
 	"github.com/mholt/caddy"
-	"k8s.io/dns/pkg/netif"
-	"k8s.io/kubernetes/pkg/util/dbus"
-	utilexec "k8s.io/kubernetes/pkg/util/exec"
-	utiliptables "k8s.io/kubernetes/pkg/util/iptables"
 )
 
-// configParams lists the configuration options that can be provided to dns-cache
-type configParams struct {
-	localIPStr           string        // comma separated listen ips for the local cache agent
-	localIPs             []net.IP      // parsed ip addresses for the local cache agent to listen for dns requests
-	localPort            string        // port to listen for dns requests
-	metricsListenAddress string        // address to serve metrics on
-	interfaceName        string        // Name of the interface to be created
-	interval             time.Duration // specifies how often to run iptables rules check
-	exitChan             chan bool     // Channel to terminate background goroutines
-}
+var cache *app.CacheApp
 
-type iptablesRule struct {
-	table utiliptables.Table
-	chain utiliptables.Chain
-	args  []string
-}
-
-type cacheApp struct {
-	setupIptables bool
-	iptables      utiliptables.Interface
-	iptablesRules []iptablesRule
-	params        configParams
-	netifHandle   *netif.NetifManager
-}
-
-var cache = cacheApp{params: configParams{localPort: "53"}}
-
-func isLockedErr(err error) bool {
-	return strings.Contains(err.Error(), "holding the xtables lock")
-}
-
-func (c *cacheApp) Init() {
-	err := c.parseAndValidateFlags()
+func init() {
+	params, err := parseAndValidateFlags()
 	if err != nil {
 		clog.Fatalf("Error parsing flags - %s, Exiting", err)
 	}
-	c.netifHandle = netif.NewNetifManager(c.params.localIPs)
-	if c.setupIptables {
-		c.initIptables()
-	}
-	err = c.teardownNetworking()
+	cache, err = app.NewCacheApp(params)
 	if err != nil {
-		// It is likely to hit errors here if previous shutdown cleaned up all iptables rules and interface.
-		// Logging error at info level
-		clog.Infof("Hit error during teardown - %s", err)
+		clog.Fatalf("Failed to obtain CacheApp instance, err %v", err)
 	}
-	err = c.setupNetworking()
-	if err != nil {
-		cache.teardownNetworking()
-		clog.Fatalf("Failed to setup - %s, Exiting", err)
-	}
-	initMetrics(c.params.metricsListenAddress)
-}
-
-func init() {
 	cache.Init()
-	caddy.OnProcessExit = append(caddy.OnProcessExit, func() { cache.teardownNetworking() })
+	caddy.OnProcessExit = append(caddy.OnProcessExit, func() { cache.TeardownNetworking() })
 }
 
-func (c *cacheApp) initIptables() {
-	// using the localIPStr param since we need ip strings here
-	for _, localIP := range strings.Split(c.params.localIPStr, ",") {
-		c.iptablesRules = append(c.iptablesRules, []iptablesRule{
-			// Match traffic destined for localIp:localPort and set the flows to be NOTRACKED, this skips connection tracking
-			{utiliptables.Table("raw"), utiliptables.ChainPrerouting, []string{"-p", "tcp", "-d", localIP,
-				"--dport", c.params.localPort, "-j", "NOTRACK"}},
-			{utiliptables.Table("raw"), utiliptables.ChainPrerouting, []string{"-p", "udp", "-d", localIP,
-				"--dport", c.params.localPort, "-j", "NOTRACK"}},
-			// There are rules in filter table to allow tracked connections to be accepted. Since we skipped connection tracking,
-			// need these additional filter table rules.
-			{utiliptables.TableFilter, utiliptables.ChainInput, []string{"-p", "tcp", "-d", localIP,
-				"--dport", c.params.localPort, "-j", "ACCEPT"}},
-			{utiliptables.TableFilter, utiliptables.ChainInput, []string{"-p", "udp", "-d", localIP,
-				"--dport", c.params.localPort, "-j", "ACCEPT"}},
-			// Match traffic from localIp:localPort and set the flows to be NOTRACKED, this skips connection tracking
-			{utiliptables.Table("raw"), utiliptables.ChainOutput, []string{"-p", "tcp", "-s", localIP,
-				"--sport", c.params.localPort, "-j", "NOTRACK"}},
-			{utiliptables.Table("raw"), utiliptables.ChainOutput, []string{"-p", "udp", "-s", localIP,
-				"--sport", c.params.localPort, "-j", "NOTRACK"}},
-			// Additional filter table rules for traffic frpm localIp:localPort
-			{utiliptables.TableFilter, utiliptables.ChainOutput, []string{"-p", "tcp", "-s", localIP,
-				"--sport", c.params.localPort, "-j", "ACCEPT"}},
-			{utiliptables.TableFilter, utiliptables.ChainOutput, []string{"-p", "udp", "-s", localIP,
-				"--sport", c.params.localPort, "-j", "ACCEPT"}},
-			// Skip connection tracking for requests to nodelocalDNS that are locally generated, example - by hostNetwork pods
-			{utiliptables.Table("raw"), utiliptables.ChainOutput, []string{"-p", "tcp", "-d", localIP,
-				"--dport", c.params.localPort, "-j", "NOTRACK"}},
-			{utiliptables.Table("raw"), utiliptables.ChainOutput, []string{"-p", "udp", "-d", localIP,
-				"--dport", c.params.localPort, "-j", "NOTRACK"}},
-		}...)
-	}
-	c.iptables = newIPTables()
-}
-
-func newIPTables() utiliptables.Interface {
-	execer := utilexec.New()
-	dbus := dbus.New()
-	return utiliptables.New(execer, dbus, utiliptables.ProtocolIpv4)
-}
-
-func (c *cacheApp) setupNetworking() error {
-	var err error
-	clog.Infof("Setting up networking for node cache")
-	err = c.netifHandle.AddDummyDevice(c.params.interfaceName)
-	if err != nil {
-		return err
-	}
-	if c.setupIptables {
-		for _, rule := range c.iptablesRules {
-			_, err = c.iptables.EnsureRule(utiliptables.Prepend, rule.table, rule.chain, rule.args...)
-			if err != nil {
-				return err
-			}
-		}
-	} else {
-		clog.Infof("Skipping iptables setup for node cache")
-	}
-	return err
-}
-
-func (c *cacheApp) teardownNetworking() error {
-	clog.Infof("Tearing down")
-	if c.params.exitChan != nil {
-		// Stop the goroutine that periodically checks for iptables rules/dummy interface
-		// exitChan is a buffered channel of size 1, so this will not block
-		c.params.exitChan <- true
-	}
-	err := c.netifHandle.RemoveDummyDevice(c.params.interfaceName)
-	if c.setupIptables {
-		for _, rule := range c.iptablesRules {
-			exists := true
-			for exists == true {
-				c.iptables.DeleteRule(rule.table, rule.chain, rule.args...)
-				exists, _ = c.iptables.EnsureRule(utiliptables.Prepend, rule.table, rule.chain, rule.args...)
-			}
-			// Delete the rule one last time since EnsureRule creates the rule if it doesn't exist
-			c.iptables.DeleteRule(rule.table, rule.chain, rule.args...)
-		}
-	}
-	return err
-}
-
-func (c *cacheApp) parseAndValidateFlags() error {
+func parseAndValidateFlags() (*app.ConfigParams, error) {
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage of %s:\n", os.Args[0])
 		fmt.Fprintf(os.Stderr, "Runs coreDNS v1.2.5 as a nodelocal cache listening on the specified ip:port")
 		flag.PrintDefaults()
 	}
 
-	flag.StringVar(&c.params.localIPStr, "localip", "", "comma-separated string of ip addresses to bind dnscache to")
-	flag.StringVar(&c.params.interfaceName, "interfacename", "nodelocaldns", "name of the interface to be created")
-	flag.DurationVar(&c.params.interval, "syncinterval", 60, "interval(in seconds) to check for iptables rules")
-	flag.StringVar(&c.params.metricsListenAddress, "metrics-listen-address", "0.0.0.0:9353", "address to serve metrics on")
-	flag.BoolVar(&c.setupIptables, "setupiptables", true, "indicates whether iptables rules should be setup")
+	params := &app.ConfigParams{LocalPort: "53"}
+
+	flag.StringVar(&params.LocalIPStr, "localip", "", "comma-separated string of ip addresses to bind dnscache to")
+	flag.StringVar(&params.InterfaceName, "interfacename", "nodelocaldns", "name of the interface to be created")
+	flag.DurationVar(&params.Interval, "syncinterval", 60, "interval(in seconds) to check for iptables rules")
+	flag.StringVar(&params.MetricsListenAddress, "metrics-listen-address", "0.0.0.0:9353", "address to serve metrics on")
+	flag.BoolVar(&params.SetupIptables, "setupiptables", true, "indicates whether iptables rules should be setup")
+	flag.StringVar(&params.BaseCoreFile, "basecorefile", "/etc/coredns/Corefile.base", "Path to the template Corefile for node-cache")
+	flag.StringVar(&params.CoreFile, "corefile", "/etc/Corefile", "Path to the Corefile to be used by node-cache")
+	flag.StringVar(&params.KubednsCMPath, "kubednscm", "/etc/kube-dns", "Path where the kube-dns configmap will be mounted")
+	flag.StringVar(&params.UpstreamSvcName, "upstreamsvc", "kube-dns", "Service name whose cluster IP is upstream for node-cache")
 	flag.Parse()
 
-	for _, ipstr := range strings.Split(c.params.localIPStr, ",") {
+	for _, ipstr := range strings.Split(params.LocalIPStr, ",") {
 		newIP := net.ParseIP(ipstr)
 		if newIP == nil {
-			return fmt.Errorf("Invalid localip specified - %q", ipstr)
+			return params, fmt.Errorf("Invalid localip specified - %q", ipstr)
 		}
-		c.params.localIPs = append(c.params.localIPs, newIP)
+		params.LocalIPs = append(params.LocalIPs, newIP)
 	}
 
 	// lookup specified dns port
-	if f := flag.Lookup("dns.port"); f == nil {
-		return fmt.Errorf("Failed to lookup \"dns.port\" parameter")
-	} else {
-		c.params.localPort = f.Value.String()
+	f := flag.Lookup("dns.port")
+	if f == nil {
+		return nil, fmt.Errorf("Failed to lookup \"dns.port\" parameter")
 	}
-	if _, err := strconv.Atoi(c.params.localPort); err != nil {
-		return fmt.Errorf("Invalid port specified - %q", c.params.localPort)
+	params.LocalPort = f.Value.String()
+	if _, err := strconv.Atoi(params.LocalPort); err != nil {
+		return nil, fmt.Errorf("Invalid port specified - %q", params.LocalPort)
 	}
-	return nil
-}
-
-func (c *cacheApp) runChecks() {
-	if c.setupIptables {
-		for _, rule := range c.iptablesRules {
-			exists, err := c.iptables.EnsureRule(utiliptables.Prepend, rule.table, rule.chain, rule.args...)
-			switch {
-			case exists:
-				// debug messages can be printed by including "debug" plugin in coreFile.
-				clog.Debugf("iptables rule %v for nodelocaldns already exists", rule)
-				continue
-			case err == nil:
-				clog.Infof("Added back nodelocaldns rule - %v", rule)
-				continue
-			// if we got here, either iptables check failed or adding rule back failed.
-			case isLockedErr(err):
-				clog.Infof("Error checking/adding iptables rule %v, due to xtables lock in use, retrying in %v", rule, c.params.interval)
-				setupErrCount.WithLabelValues("iptables_lock").Inc()
-			default:
-				clog.Errorf("Error adding iptables rule %v - %s", rule, err)
-				setupErrCount.WithLabelValues("iptables").Inc()
-			}
-		}
+	if f = flag.Lookup("conf"); f != nil {
+		params.CoreFile = f.Value.String()
+		clog.Infof("Using Corefile %s", params.CoreFile)
 	}
-
-	exists, err := c.netifHandle.EnsureDummyDevice(c.params.interfaceName)
-	if !exists {
-		if err != nil {
-			clog.Errorf("Failed to add non-existent interface %s: %s", c.params.interfaceName, err)
-			setupErrCount.WithLabelValues("interface_add").Inc()
-		}
-		clog.Infof("Added back interface - %s", c.params.interfaceName)
-	}
-	if err != nil {
-		clog.Errorf("Error checking dummy device %s - %s", c.params.interfaceName, err)
-		setupErrCount.WithLabelValues("interface_check").Inc()
-	}
-}
-
-func (c *cacheApp) run() {
-	c.params.exitChan = make(chan bool, 1)
-	tick := time.NewTicker(c.params.interval * time.Second)
-	for {
-		select {
-		case <-tick.C:
-			c.runChecks()
-		case <-c.params.exitChan:
-			clog.Warningf("Exiting iptables/interface check goroutine")
-			return
-		}
-	}
+	return params, nil
 }
 
 func main() {
-	// Ensure that the required setup is ready
-	// https://github.com/kubernetes/dns/issues/282 sometimes the interface gets the ip and then loses it, if added too soon.
-	cache.runChecks()
-	go cache.run()
-	coremain.Run()
-	// Unlikely to reach here, if we did it is because coremain exited and the signal was not trapped.
-	clog.Errorf("Untrapped signal, tearing down")
-	cache.teardownNetworking()
+	cache.RunApp()
 }


### PR DESCRIPTION
This change adds functionality in node-cache to generate the Corefile based on stubDomain and upstream servers config in kube-dns config map. This requires the kube-dns configmap to be mounted in the local filesystem.

The nodelocaldns yaml will look like this - https://github.com/kubernetes/kubernetes/commit/af3316b6c4d58814d86bb4b40ebfe80ddc949659