### PR TITLE
Debian base uses `nogroup` as the group

### DIFF
--- a/Dockerfile.sidecar
+++ b/Dockerfile.sidecar
@@ -18,5 +18,5 @@ MAINTAINER Bowei Du <bowei@google.com>
 
 ADD bin/ARG_ARCH/ARG_BIN /ARG_BIN
 
-USER nobody:nobody
+USER nobody:nogroup
 ENTRYPOINT ["/ARG_BIN"]


### PR DESCRIPTION
Fixes: https://github.com/kubernetes/dns/issues/321

/assign @MrHohn @prameshj 