### PR TITLE
Add loadbalance, whoami plugins

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -54,7 +54,7 @@
   version = "v3.0.0"
 
 [[projects]]
-  digest = "1:7f9921e0956bf7a8a8fbf62e35758504dbfd6599bc402e996a0c9a5589ba3d0b"
+  digest = "1:667ed82ad1f40f34b6e1004f0c954f011e31bf1e07a6827ee4383d7f37c523f4"
   name = "github.com/coredns/coredns"
   packages = [
     "core/dnsserver",
@@ -73,6 +73,7 @@
     "plugin/etcd/msg",
     "plugin/forward",
     "plugin/health",
+    "plugin/loadbalance",
     "plugin/log",
     "plugin/loop",
     "plugin/metadata",
@@ -100,6 +101,7 @@
     "plugin/pprof",
     "plugin/reload",
     "plugin/test",
+    "plugin/whoami",
     "request",
   ]
   pruneopts = "UT"
@@ -970,12 +972,14 @@
     "github.com/coredns/coredns/plugin/errors",
     "github.com/coredns/coredns/plugin/forward",
     "github.com/coredns/coredns/plugin/health",
+    "github.com/coredns/coredns/plugin/loadbalance",
     "github.com/coredns/coredns/plugin/log",
     "github.com/coredns/coredns/plugin/loop",
     "github.com/coredns/coredns/plugin/metrics",
     "github.com/coredns/coredns/plugin/pkg/log",
     "github.com/coredns/coredns/plugin/pprof",
     "github.com/coredns/coredns/plugin/reload",
+    "github.com/coredns/coredns/plugin/whoami",
     "github.com/coreos/etcd/client",
     "github.com/golang/glog",
     "github.com/miekg/dns",

--- a/cmd/node-cache/main.go
+++ b/cmd/node-cache/main.go
@@ -22,11 +22,13 @@ import (
 	_ "github.com/coredns/coredns/plugin/errors"
 	_ "github.com/coredns/coredns/plugin/forward"
 	_ "github.com/coredns/coredns/plugin/health"
+	_ "github.com/coredns/coredns/plugin/loadbalance"
 	_ "github.com/coredns/coredns/plugin/log"
 	_ "github.com/coredns/coredns/plugin/loop"
 	_ "github.com/coredns/coredns/plugin/metrics"
 	_ "github.com/coredns/coredns/plugin/pprof"
 	_ "github.com/coredns/coredns/plugin/reload"
+	_ "github.com/coredns/coredns/plugin/whoami"
 )
 
 var cache *app.CacheApp

--- a/vendor/github.com/coredns/coredns/plugin/loadbalance/README.md
+++ b/vendor/github.com/coredns/coredns/plugin/loadbalance/README.md
@@ -1,0 +1,33 @@
+# loadbalance
+
+## Name
+
+*loadbalance* - randomizes the order of A, AAAA and MX records.
+
+## Description
+
+The *loadbalance* will act as a round-robin DNS load balancer by randomizing the order of A, AAAA,
+and MX records in the answer.
+
+See [Wikipedia](https://en.wikipedia.org/wiki/Round-robin_DNS) about the pros and cons of this
+setup. It will take care to sort any CNAMEs before any address records, because some stub resolver
+implementations (like glibc) are particular about that.
+
+## Syntax
+
+~~~
+loadbalance [POLICY]
+~~~
+
+* **POLICY** is how to balance. The default, and only option, is "round_robin".
+
+## Examples
+
+Load balance replies coming back from Google Public DNS:
+
+~~~ corefile
+. {
+    loadbalance round_robin
+    forward . 8.8.8.8 8.8.4.4
+}
+~~~

--- a/vendor/github.com/coredns/coredns/plugin/loadbalance/handler.go
+++ b/vendor/github.com/coredns/coredns/plugin/loadbalance/handler.go
@@ -1,0 +1,24 @@
+// Package loadbalance is a plugin for rewriting responses to do "load balancing"
+package loadbalance
+
+import (
+	"context"
+
+	"github.com/coredns/coredns/plugin"
+
+	"github.com/miekg/dns"
+)
+
+// RoundRobin is a plugin to rewrite responses for "load balancing".
+type RoundRobin struct {
+	Next plugin.Handler
+}
+
+// ServeDNS implements the plugin.Handler interface.
+func (rr RoundRobin) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	wrr := &RoundRobinResponseWriter{w}
+	return plugin.NextOrFailure(rr.Name(), rr.Next, ctx, wrr, r)
+}
+
+// Name implements the Handler interface.
+func (rr RoundRobin) Name() string { return "loadbalance" }

--- a/vendor/github.com/coredns/coredns/plugin/loadbalance/loadbalance.go
+++ b/vendor/github.com/coredns/coredns/plugin/loadbalance/loadbalance.go
@@ -1,0 +1,81 @@
+// Package loadbalance shuffles A, AAAA and MX records.
+package loadbalance
+
+import (
+	"github.com/miekg/dns"
+)
+
+// RoundRobinResponseWriter is a response writer that shuffles A, AAAA and MX records.
+type RoundRobinResponseWriter struct{ dns.ResponseWriter }
+
+// WriteMsg implements the dns.ResponseWriter interface.
+func (r *RoundRobinResponseWriter) WriteMsg(res *dns.Msg) error {
+	if res.Rcode != dns.RcodeSuccess {
+		return r.ResponseWriter.WriteMsg(res)
+	}
+
+	if res.Question[0].Qtype == dns.TypeAXFR || res.Question[0].Qtype == dns.TypeIXFR {
+		return r.ResponseWriter.WriteMsg(res)
+	}
+
+	res.Answer = roundRobin(res.Answer)
+	res.Ns = roundRobin(res.Ns)
+	res.Extra = roundRobin(res.Extra)
+
+	return r.ResponseWriter.WriteMsg(res)
+}
+
+func roundRobin(in []dns.RR) []dns.RR {
+	cname := []dns.RR{}
+	address := []dns.RR{}
+	mx := []dns.RR{}
+	rest := []dns.RR{}
+	for _, r := range in {
+		switch r.Header().Rrtype {
+		case dns.TypeCNAME:
+			cname = append(cname, r)
+		case dns.TypeA, dns.TypeAAAA:
+			address = append(address, r)
+		case dns.TypeMX:
+			mx = append(mx, r)
+		default:
+			rest = append(rest, r)
+		}
+	}
+
+	roundRobinShuffle(address)
+	roundRobinShuffle(mx)
+
+	out := append(cname, rest...)
+	out = append(out, address...)
+	out = append(out, mx...)
+	return out
+}
+
+func roundRobinShuffle(records []dns.RR) {
+	switch l := len(records); l {
+	case 0, 1:
+		break
+	case 2:
+		if dns.Id()%2 == 0 {
+			records[0], records[1] = records[1], records[0]
+		}
+	default:
+		for j := 0; j < l*(int(dns.Id())%4+1); j++ {
+			q := int(dns.Id()) % l
+			p := int(dns.Id()) % l
+			if q == p {
+				p = (p + 1) % l
+			}
+			records[q], records[p] = records[p], records[q]
+		}
+	}
+}
+
+// Write implements the dns.ResponseWriter interface.
+func (r *RoundRobinResponseWriter) Write(buf []byte) (int, error) {
+	// Should we pack and unpack here to fiddle with the packet... Not likely.
+	log.Warning("RoundRobin called with Write: not shuffling records")
+	n, err := r.ResponseWriter.Write(buf)
+	return n, err
+}

--- a/vendor/github.com/coredns/coredns/plugin/loadbalance/setup.go
+++ b/vendor/github.com/coredns/coredns/plugin/loadbalance/setup.go
@@ -1,0 +1,45 @@
+package loadbalance
+
+import (
+	"fmt"
+
+	"github.com/coredns/coredns/core/dnsserver"
+	"github.com/coredns/coredns/plugin"
+	clog "github.com/coredns/coredns/plugin/pkg/log"
+
+	"github.com/caddyserver/caddy"
+)
+
+var log = clog.NewWithPlugin("loadbalance")
+
+func init() { plugin.Register("loadbalance", setup) }
+
+func setup(c *caddy.Controller) error {
+	err := parse(c)
+	if err != nil {
+		return plugin.Error("loadbalance", err)
+	}
+
+	dnsserver.GetConfig(c).AddPlugin(func(next plugin.Handler) plugin.Handler {
+		return RoundRobin{Next: next}
+	})
+
+	return nil
+}
+
+func parse(c *caddy.Controller) error {
+	for c.Next() {
+		args := c.RemainingArgs()
+		switch len(args) {
+		case 0:
+			return nil
+		case 1:
+			if args[0] != "round_robin" {
+				return fmt.Errorf("unknown policy: %s", args[0])
+
+			}
+			return nil
+		}
+	}
+	return c.ArgErr()
+}

--- a/vendor/github.com/coredns/coredns/plugin/whoami/README.md
+++ b/vendor/github.com/coredns/coredns/plugin/whoami/README.md
@@ -1,0 +1,58 @@
+# whoami
+
+## Name
+
+*whoami* - returns your resolver's local IP address, port and transport.
+
+## Description
+
+The *whoami* plugin is not really that useful, but can be used for having a simple (fast) endpoint
+to test clients against. When *whoami* returns a response it will have your client's IP address in
+the additional section as either an A or AAAA record.
+
+The reply always has an empty answer section. The port and transport are included in the additional
+section as a SRV record, transport can be "tcp" or "udp".
+
+~~~ txt
+._<transport>.qname. 0 IN SRV 0 0 <port> .
+~~~
+
+The *whoami* plugin will respond to every A or AAAA query, regardless of the query name.
+
+If CoreDNS can't find a Corefile on startup this is the _default_ plugin that gets loaded. As such
+it can be used to check that CoreDNS is responding to queries. Other than that this plugin is of
+limited use in production.
+
+## Syntax
+
+~~~ txt
+whoami
+~~~
+
+## Examples
+
+Start a server on the default port and load the *whoami* plugin.
+
+~~~ corefile
+example.org {
+    whoami
+}
+~~~
+
+When queried for "example.org A", CoreDNS will respond with:
+
+~~~ txt
+;; QUESTION SECTION:
+;example.org.   IN       A
+
+;; ADDITIONAL SECTION:
+example.org.            0       IN      A       10.240.0.1
+_udp.example.org.       0       IN      SRV     0 0 40212
+~~~
+
+## See Also
+
+[Read the blog post][blog] on how this plugin is built, or [explore the source code][code].
+
+[blog]: https://coredns.io/2017/03/01/how-to-add-plugins-to-coredns/
+[code]: https://github.com/coredns/coredns/blob/master/plugin/whoami/

--- a/vendor/github.com/coredns/coredns/plugin/whoami/fuzz.go
+++ b/vendor/github.com/coredns/coredns/plugin/whoami/fuzz.go
@@ -1,0 +1,13 @@
+// +build gofuzz
+
+package whoami
+
+import (
+	"github.com/coredns/coredns/plugin/pkg/fuzz"
+)
+
+// Fuzz fuzzes cache.
+func Fuzz(data []byte) int {
+	w := Whoami{}
+	return fuzz.Do(w, data)
+}

--- a/vendor/github.com/coredns/coredns/plugin/whoami/setup.go
+++ b/vendor/github.com/coredns/coredns/plugin/whoami/setup.go
@@ -1,0 +1,23 @@
+package whoami
+
+import (
+	"github.com/coredns/coredns/core/dnsserver"
+	"github.com/coredns/coredns/plugin"
+
+	"github.com/caddyserver/caddy"
+)
+
+func init() { plugin.Register("whoami", setup) }
+
+func setup(c *caddy.Controller) error {
+	c.Next() // 'whoami'
+	if c.NextArg() {
+		return plugin.Error("whoami", c.ArgErr())
+	}
+
+	dnsserver.GetConfig(c).AddPlugin(func(next plugin.Handler) plugin.Handler {
+		return Whoami{}
+	})
+
+	return nil
+}

--- a/vendor/github.com/coredns/coredns/plugin/whoami/whoami.go
+++ b/vendor/github.com/coredns/coredns/plugin/whoami/whoami.go
@@ -1,0 +1,58 @@
+// Package whoami implements a plugin that returns details about the resolving
+// querying it.
+package whoami
+
+import (
+	"context"
+	"net"
+	"strconv"
+
+	"github.com/coredns/coredns/request"
+
+	"github.com/miekg/dns"
+)
+
+// Whoami is a plugin that returns your IP address, port and the protocol used for connecting
+// to CoreDNS.
+type Whoami struct{}
+
+// ServeDNS implements the plugin.Handler interface.
+func (wh Whoami) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	state := request.Request{W: w, Req: r}
+
+	a := new(dns.Msg)
+	a.SetReply(r)
+	a.Authoritative = true
+
+	ip := state.IP()
+	var rr dns.RR
+
+	switch state.Family() {
+	case 1:
+		rr = new(dns.A)
+		rr.(*dns.A).Hdr = dns.RR_Header{Name: state.QName(), Rrtype: dns.TypeA, Class: state.QClass()}
+		rr.(*dns.A).A = net.ParseIP(ip).To4()
+	case 2:
+		rr = new(dns.AAAA)
+		rr.(*dns.AAAA).Hdr = dns.RR_Header{Name: state.QName(), Rrtype: dns.TypeAAAA, Class: state.QClass()}
+		rr.(*dns.AAAA).AAAA = net.ParseIP(ip)
+	}
+
+	srv := new(dns.SRV)
+	srv.Hdr = dns.RR_Header{Name: "_" + state.Proto() + "." + state.QName(), Rrtype: dns.TypeSRV, Class: state.QClass()}
+	if state.QName() == "." {
+		srv.Hdr.Name = "_" + state.Proto() + state.QName()
+	}
+	port, _ := strconv.Atoi(state.Port())
+	srv.Port = uint16(port)
+	srv.Target = "."
+
+	a.Extra = []dns.RR{rr, srv}
+
+	w.WriteMsg(a)
+
+	return 0, nil
+}
+
+// Name implements the Handler interface.
+func (wh Whoami) Name() string { return "whoami" }


### PR DESCRIPTION
I'd like to enable the plugins `loadbalance` and `whoami`

- loadbalance is useful because of how consul returns records (large sets of A records which are randomized on retrieval). However, coredns doesn't randomize this set. So the records remain ordered until a new set is retrieved. I'm worried that this will cause hotspotting.
- whoami is useful because "we can add node.cluster.local as a zone that resolves to the host ip. Then we can put that value into configmaps, vs having to use downward api and hacks (since configmaps don't natively support that). Our specific use case is a node local memcached instance listening on a hostport" -@gbrayut

I've tested node-local-dns with the new plugins. It works, and the new loadbalance plugin is present.

## Test config

```
apiVersion: v1
data:
  Corefile: |
    cluster.local:53 {
        errors
        cache {
                success 9984 30
                denial 9984 5
        }
        reload
        loop
        bind 169.254.20.10
        forward . 192.168.0.10 {
                force_tcp
        }
        prometheus :9253
        health 169.254.20.10:8080
        }
    in-addr.arpa:53 {
        errors
        cache 30
        reload
        loop
        bind 169.254.20.10
        forward . 192.168.0.10 {
                force_tcp
        }
        prometheus :9253
        }
    ip6.arpa:53 {
        errors
        cache 30
        reload
        loop
        bind 169.254.20.10
        forward . 192.168.0.10 {
                force_tcp
        }
        prometheus :9253
        }
    .:53 {
        errors
        cache 30
        reload
        loop
        bind 169.254.20.10
        forward . /etc/resolv.conf {
                force_tcp
        }
        prometheus :9253
        }
    consul:53 {
        errors
        cache 30 {
                prefetch 90
                serve_stale
        }
        reload
        loop
        loadbalance round_robin
        # bind 169.254.20.10
        # IPs changed for privacy
        forward . 10.0.1.10 10.0.2.10 10.0.3.10 {
                force_tcp
        }
        prometheus :9253
        }
...
```
## Log output

```
2020/02/15 00:51:35 [INFO] Using Corefile /etc/coredns/Corefile
2020/02/15 00:51:35 [INFO] Tearing down
2020/02/15 00:51:35 [INFO] Hit error during teardown - Link not found
2020/02/15 00:51:35 [INFO] Setting up networking for node cache
2020/02/15 00:51:36 [ERROR] Failed to read node-cache coreFile /etc/coredns/Corefile.base - open /etc/coredns/Corefile.base: no such file or directory
2020/02/15 00:51:36 [ERROR] Failed to sync kube-dns config directory /etc/kube-dns, err: lstat /etc/kube-dns: no such file or directory
in-addr.arpa.:53 on 169.254.20.10
ip6.arpa.:53 on 169.254.20.10
.:53 on 169.254.20.10
cluster.local.:53 on 169.254.20.10
consul.:53
[INFO] plugin/reload: Running configuration MD5 = 9ce2021cd94d32550273d0ab031bf343
CoreDNS-1.6.7
linux/amd64, go1.11.13,
```

I can do `dig listing.service.consul @localhost` and the expected consul record is returned.