### PR TITLE
Fix build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,13 @@ This is the repository for [Kubernetes DNS](http://kubernetes.io/docs/admin/dns/
 
 | target | description |
 | ---- | ---- |
-|all, build | build all binaries |
-|test       | run unit tests |
-|containers | build the containers |
-|push       | push containers to the registry |
-|help       | this help message |
-|version    | show package version |
+|all, build   | build all binaries |
+|test         | run unit tests |
+|containers   | build the containers |
+|images-clean | clear image build artifacts from workdir |
+|push         | push containers to the registry |
+|help         | this help message |
+|version      | show package version |
 |{build,containers,push}-ARCH | do action for specific ARCH |
 |all-{build,containers,push}  | do action for all ARCH |
 |only-push-BINARY             | push just BINARY |
@@ -35,7 +36,7 @@ This is the repository for [Kubernetes DNS](http://kubernetes.io/docs/admin/dns/
 
 ## Release process
 
-1. Build and test (`make build` and `make test`)
+1. Build and test (`make images-clean`; `make build`; `make containers`; `make test`)
 1. Update [go dependencies](docs/go-dependencies.md) if needed.
 1. Update the release tag. We use [semantic versioning](http://semver.org) to
    name releases.

--- a/rules.mk
+++ b/rules.mk
@@ -241,6 +241,7 @@ help:
 	@echo "  all, build    build all binaries"
 	@echo "  containers    build the containers"
 	@echo "  push          push containers to the registry"
+	@echo "  images-clean  clear image build artifacts from workdir"
 	@echo "  help          this help message"
 	@echo "  version       show package version"
 	@echo


### PR DESCRIPTION
The current build docs only work for the first build.

If you:

- make build; make containers; make test
- Commit
- make build; make containers; make test

The final build will not find base images and fail.