### PR TITLE
modify cache_app_test to sleep for more time.

### DIFF
--- a/cmd/node-cache/app/cache_app_test.go
+++ b/cmd/node-cache/app/cache_app_test.go
@@ -144,7 +144,7 @@ func TestUpdateCoreFile(t *testing.T) {
 	expectedStubStr := getStubDomainStr(customConfig.StubDomains, &stubDomainInfo{Port: c.params.LocalPort, CacheTTL: defaultTTL,
 		LocalIP: strings.Replace(c.params.LocalIPStr, ",", " ", -1)})
 
-	time.Sleep(10 * time.Second)
+	time.Sleep(15 * time.Second)
 	out, _ := compareFileContents(c.params.CoreFile, expectedContents, t)
 	if !strings.Contains(out, expectedContents) {
 		t.Fatalf("Could not find contents '%s' in CoreFile '%s'", expectedContents, out)


### PR DESCRIPTION
The config sync interval is 10s. Sometimes the test fails since it sleeps for 10s and the sync has not happened yet.