### PR TITLE
Add a flag to skip teardown in node-cache.

### DIFF
--- a/cmd/node-cache/app/cache_app.go
+++ b/cmd/node-cache/app/cache_app.go
@@ -33,6 +33,7 @@ type ConfigParams struct {
 	UpstreamSvcName      string        // Name of the service whose clusterIP is the upstream for node-cache for cluster domain
 	HealthPort           string        // port for the healthcheck
 	SetupIptables        bool
+	SkipTeardown         bool // Indicates whether the iptables rules and interface should be torn down
 }
 
 type iptablesRule struct {

--- a/cmd/node-cache/main.go
+++ b/cmd/node-cache/main.go
@@ -43,7 +43,9 @@ func init() {
 		clog.Fatalf("Failed to obtain CacheApp instance, err %v", err)
 	}
 	cache.Init()
-	caddy.OnProcessExit = append(caddy.OnProcessExit, func() { cache.TeardownNetworking() })
+	if !params.SkipTeardown {
+		caddy.OnProcessExit = append(caddy.OnProcessExit, func() { cache.TeardownNetworking() })
+	}
 }
 
 func parseAndValidateFlags() (*app.ConfigParams, error) {
@@ -65,6 +67,7 @@ func parseAndValidateFlags() (*app.ConfigParams, error) {
 	flag.StringVar(&params.KubednsCMPath, "kubednscm", "/etc/kube-dns", "Path where the kube-dns configmap will be mounted")
 	flag.StringVar(&params.UpstreamSvcName, "upstreamsvc", "kube-dns", "Service name whose cluster IP is upstream for node-cache")
 	flag.StringVar(&params.HealthPort, "health-port", "8080", "port used by health plugin")
+	flag.BoolVar(&params.SkipTeardown, "skipteardown", false, "indicates whether iptables rules should be torn down on exit")
 	flag.Parse()
 
 	for _, ipstr := range strings.Split(params.LocalIPStr, ",") {


### PR DESCRIPTION
This is useful when running multiple node-cache instances for HA.
The rules/interface shouldn't be torn down when one of them exit.