### PR TITLE
Fix skipteardown flag not completely avoiding teardown

### DIFF
--- a/cmd/node-cache/app/cache_app.go
+++ b/cmd/node-cache/app/cache_app.go
@@ -68,14 +68,6 @@ func (c *CacheApp) Init() {
 	// this is required in case there is no kube-dns configmap specified.
 	c.updateCorefile(&config.Config{})
 	c.initKubeDNSConfigSync()
-	if !c.params.SkipTeardown {
-		err := c.TeardownNetworking()
-		if err != nil {
-			// It is likely to hit errors here if previous shutdown cleaned up all iptables rules and interface.
-			// Logging error at info level
-			clog.Infof("Hit error during teardown - %s", err)
-		}
-	}
 	c.setupNetworking()
 }
 

--- a/cmd/node-cache/app/cache_app.go
+++ b/cmd/node-cache/app/cache_app.go
@@ -68,11 +68,13 @@ func (c *CacheApp) Init() {
 	// this is required in case there is no kube-dns configmap specified.
 	c.updateCorefile(&config.Config{})
 	c.initKubeDNSConfigSync()
-	err := c.TeardownNetworking()
-	if err != nil {
-		// It is likely to hit errors here if previous shutdown cleaned up all iptables rules and interface.
-		// Logging error at info level
-		clog.Infof("Hit error during teardown - %s", err)
+	if !c.params.SkipTeardown {
+		err := c.TeardownNetworking()
+		if err != nil {
+			// It is likely to hit errors here if previous shutdown cleaned up all iptables rules and interface.
+			// Logging error at info level
+			clog.Infof("Hit error during teardown - %s", err)
+		}
 	}
 	c.setupNetworking()
 }


### PR DESCRIPTION
When using an HA setup of nodecache, it is imperative to avoid that one
instance of nodecache tear down networking at any time, to avoid disrupting
functionalities for the second instance, which is sharing the same interface
and iptables rules.

This fix addresses the issue of nodecache trying to tear down networking
at startup, right before ensuring it is setup again. When `--skipteardown`
flag is passed, nodecache should not try to do so, but instead simply
ensure that networking is correctly setup.

This should fix #358 