### PR TITLE
Revert "Use debian-iptables-$(ARCH):v12.0.1 and debian-base-$(ARCH):v2.0.0"

### DIFF
--- a/Dockerfile.node-cache
+++ b/Dockerfile.node-cache
@@ -13,6 +13,10 @@
 # limitations under the License.
 
 FROM ARG_FROM
+RUN apt-get update && apt-get install -y \
+    iproute2 \
+    iptables \
+&& rm -rf /var/lib/apt/lists/*
 ADD bin/ARG_ARCH/ARG_BIN /ARG_BIN
 EXPOSE 53 53/udp
 EXPOSE 53 53/tcp

--- a/images/dnsmasq/Makefile
+++ b/images/dnsmasq/Makefile
@@ -27,21 +27,25 @@ OUTPUT_DIR := _output/$(ARCH)
 # Ensure that the docker command line supports the manifest images
 export DOCKER_CLI_EXPERIMENTAL=enabled
 
-BASEIMAGE ?= k8s.gcr.io/debian-base-$(ARCH):v2.0.0
 ifeq ($(ARCH),amd64)
-	COMPILE_IMAGE := k8s.gcr.io/debian-base-$(ARCH):v2.0.0
+	BASEIMAGE ?= k8s.gcr.io/debian-base:v1.0.0
+	COMPILE_IMAGE := k8s.gcr.io/debian-base:v1.0.0
 else ifeq ($(ARCH),arm)
+	BASEIMAGE ?= k8s.gcr.io/debian-base-arm:v1.0.0
 	TRIPLE    ?= arm-linux-gnueabihf
 	QEMUARCH  := arm
 else ifeq ($(ARCH),arm64)
+	BASEIMAGE ?= k8s.gcr.io/debian-base-arm64:v1.0.0
 	TRIPLE    ?= aarch64-linux-gnu
 	QEMUARCH  := aarch64
 else ifeq ($(ARCH),ppc64le)
+	BASEIMAGE ?= k8s.gcr.io/debian-base-ppc64le:v1.0.0
 	TRIPLE    ?= powerpc64le-linux-gnu
 	QEMUARCH  := ppc64le
 else ifeq ($(ARCH),s390x)
-	TRIPLE    ?= s390x-linux-gnu
-	QEMUARCH  := s390x
+        BASEIMAGE ?=k8s.gcr.io/debian-base-s390x:v1.0.0
+        TRIPLE    ?=s390x-linux-gnu
+        QEMUARCH  :=s390x
 else
 $(error Unsupported ARCH: $(ARCH))
 endif

--- a/rules.mk
+++ b/rules.mk
@@ -29,10 +29,21 @@ export VERSION
 SRC_DIRS := cmd pkg
 
 ALL_ARCH := amd64 arm arm64 ppc64le s390x
-ifeq ($(BINARY),node-cache)
-BASEIMAGE ?= k8s.gcr.io/debian-iptables-$(ARCH):v12.0.1
-else
-BASEIMAGE ?= k8s.gcr.io/debian-base-$(ARCH):v2.0.0
+# Set default base image dynamically for each arch
+ifeq ($(ARCH),amd64)
+	BASEIMAGE?=k8s.gcr.io/debian-base:v1.0.0
+endif
+ifeq ($(ARCH),arm)
+	BASEIMAGE?=k8s.gcr.io/debian-base-arm:v1.0.0
+endif
+ifeq ($(ARCH),arm64)
+	BASEIMAGE?=k8s.gcr.io/debian-base-arm64:v1.0.0
+endif
+ifeq ($(ARCH),ppc64le)
+	BASEIMAGE?=k8s.gcr.io/debian-base-ppc64le:v1.0.0
+endif
+ifeq ($(ARCH),s390x)
+	BASEIMAGE?=k8s.gcr.io/debian-base-s390x:v1.0.0
 endif
 
 # These rules MUST be expanded at reference time (hence '=') as BINARY


### PR DESCRIPTION
Reverts kubernetes/dns#355

This causes node-cache image to fail since iptables is not found.
@champtar i am reverting this, feel free to submit a new PR with the changes enabled.
