### PR TITLE
Use debian-iptables for k8s-dns-node-cache, bump debian-base version

### DIFF
--- a/Dockerfile.kube-dns
+++ b/Dockerfile.kube-dns
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ARG_FROM
+FROM ARG_FROM_BASE
 
 MAINTAINER Bowei Du <bowei@google.com>
 

--- a/Dockerfile.node-cache
+++ b/Dockerfile.node-cache
@@ -12,18 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ARG_FROM
-# Use --no-install-recommends to not install nftables and work around https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=956655
-# Use iptables-legacy only until https://bugzilla.netfilter.org/show_bug.cgi?id=1422 is resolved
-# once fixed we will switch to k8s.gcr.io/debian-iptables-$(ARCH) to choose iptables-legacy or iptables-nft at run time
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    iproute2 \
-    iptables \
-    ebtables \
-&& update-alternatives --set iptables /usr/sbin/iptables-legacy \
-&& update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy \
-&& update-alternatives --set ebtables /usr/sbin/ebtables-legacy \
-&& rm -rf /var/lib/apt/lists/*
+FROM ARG_FROM_IPT
+RUN update-alternatives --set ebtables /usr/sbin/ebtables-legacy
 ADD bin/ARG_ARCH/ARG_BIN /ARG_BIN
 EXPOSE 53 53/udp
 EXPOSE 53 53/tcp

--- a/Dockerfile.sidecar
+++ b/Dockerfile.sidecar
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ARG_FROM
+FROM ARG_FROM_BASE
 
 MAINTAINER Bowei Du <bowei@google.com>
 

--- a/images/dnsmasq/Makefile
+++ b/images/dnsmasq/Makefile
@@ -27,9 +27,9 @@ OUTPUT_DIR := _output/$(ARCH)
 # Ensure that the docker command line supports the manifest images
 export DOCKER_CLI_EXPERIMENTAL=enabled
 
-BASEIMAGE ?= us.gcr.io/k8s-artifacts-prod/build-image/debian-base-$(ARCH):v2.1.2
+BASEIMAGE ?= k8s.gcr.io/build-image/debian-base-$(ARCH):buster-v1.2.0
 ifeq ($(ARCH),amd64)
-	COMPILE_IMAGE := us.gcr.io/k8s-artifacts-prod/build-image/debian-base-$(ARCH):v2.1.2
+	COMPILE_IMAGE := k8s.gcr.io/build-image/debian-base-$(ARCH):buster-v1.2.0
 else ifeq ($(ARCH),arm)
 	TRIPLE    ?= arm-linux-gnueabihf
 	QEMUARCH  := arm

--- a/rules.mk
+++ b/rules.mk
@@ -29,7 +29,8 @@ export VERSION
 SRC_DIRS := cmd pkg
 
 ALL_ARCH := amd64 arm arm64 ppc64le s390x
-BASEIMAGE ?= us.gcr.io/k8s-artifacts-prod/build-image/debian-base-$(ARCH):v2.1.2
+BASEIMAGE ?= k8s.gcr.io/build-image/debian-base-$(ARCH):buster-v1.2.0
+IPTIMAGE ?= k8s.gcr.io/build-image/debian-iptables-$(ARCH):buster-v1.3.0
 
 # These rules MUST be expanded at reference time (hence '=') as BINARY
 # is dynamically scoped.
@@ -125,7 +126,8 @@ define DOCKERFILE_RULE
 	    -e 's|ARG_ARCH|$(ARCH)|g' \
 	    -e 's|ARG_BIN|$(BINARY)|g' \
 	    -e 's|ARG_REGISTRY|$(REGISTRY)|g' \
-	    -e 's|ARG_FROM|$(BASEIMAGE)|g' \
+	    -e 's|ARG_FROM_BASE|$(BASEIMAGE)|g' \
+	    -e 's|ARG_FROM_IPT|$(IPTIMAGE)|g' \
 	    -e 's|ARG_VERSION|$(VERSION)|g' \
 	    $$< > $$@
 .$(BUILDSTAMP_NAME)-container: .$(BINARY)-$(ARCH)-dockerfile
@@ -137,7 +139,6 @@ $(foreach BINARY,$(CONTAINER_BINARIES),$(eval $(DOCKERFILE_RULE)))
 define CONTAINER_RULE
 .$(BUILDSTAMP_NAME)-container: bin/$(ARCH)/$(BINARY)
 	@echo "container: bin/$(ARCH)/$(BINARY) ($(CONTAINER_NAME))"
-	@docker pull $(BASEIMAGE)
 	@docker build					\
 		$(DOCKER_BUILD_FLAGS)			\
 		-t $(CONTAINER_NAME):$(VERSION)		\


### PR DESCRIPTION
debian-iptables container transparently select iptables-legacy or iptables-nft since v12.0.0:
kubernetes/kubernetes#82966
This fixes #338