### PR TITLE
Use debian-base-$(ARCH):v2.0.0 as base image

### DIFF
--- a/Dockerfile.node-cache
+++ b/Dockerfile.node-cache
@@ -13,9 +13,14 @@
 # limitations under the License.
 
 FROM ARG_FROM
-RUN apt-get update && apt-get install -y \
+# Use --no-install-recommends to not install nftables and work around https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=956655
+# Use iptables-legacy only until https://bugzilla.netfilter.org/show_bug.cgi?id=1422 is resolved
+# once fixed we will switch to k8s.gcr.io/debian-iptables-$(ARCH) to choose iptables-legacy or iptables-nft at run time
+RUN apt-get update && apt-get install -y --no-install-recommends \
     iproute2 \
     iptables \
+&& update-alternatives --set iptables /usr/sbin/iptables-legacy \
+&& update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy \
 && rm -rf /var/lib/apt/lists/*
 ADD bin/ARG_ARCH/ARG_BIN /ARG_BIN
 EXPOSE 53 53/udp

--- a/images/dnsmasq/Makefile
+++ b/images/dnsmasq/Makefile
@@ -27,25 +27,21 @@ OUTPUT_DIR := _output/$(ARCH)
 # Ensure that the docker command line supports the manifest images
 export DOCKER_CLI_EXPERIMENTAL=enabled
 
+BASEIMAGE ?= k8s.gcr.io/debian-base-$(ARCH):v2.0.0
 ifeq ($(ARCH),amd64)
-	BASEIMAGE ?= k8s.gcr.io/debian-base:v1.0.0
-	COMPILE_IMAGE := k8s.gcr.io/debian-base:v1.0.0
+	COMPILE_IMAGE := k8s.gcr.io/debian-base-$(ARCH):v2.0.0
 else ifeq ($(ARCH),arm)
-	BASEIMAGE ?= k8s.gcr.io/debian-base-arm:v1.0.0
 	TRIPLE    ?= arm-linux-gnueabihf
 	QEMUARCH  := arm
 else ifeq ($(ARCH),arm64)
-	BASEIMAGE ?= k8s.gcr.io/debian-base-arm64:v1.0.0
 	TRIPLE    ?= aarch64-linux-gnu
 	QEMUARCH  := aarch64
 else ifeq ($(ARCH),ppc64le)
-	BASEIMAGE ?= k8s.gcr.io/debian-base-ppc64le:v1.0.0
 	TRIPLE    ?= powerpc64le-linux-gnu
 	QEMUARCH  := ppc64le
 else ifeq ($(ARCH),s390x)
-        BASEIMAGE ?=k8s.gcr.io/debian-base-s390x:v1.0.0
-        TRIPLE    ?=s390x-linux-gnu
-        QEMUARCH  :=s390x
+	TRIPLE    ?= s390x-linux-gnu
+	QEMUARCH  := s390x
 else
 $(error Unsupported ARCH: $(ARCH))
 endif

--- a/rules.mk
+++ b/rules.mk
@@ -29,22 +29,7 @@ export VERSION
 SRC_DIRS := cmd pkg
 
 ALL_ARCH := amd64 arm arm64 ppc64le s390x
-# Set default base image dynamically for each arch
-ifeq ($(ARCH),amd64)
-	BASEIMAGE?=k8s.gcr.io/debian-base:v1.0.0
-endif
-ifeq ($(ARCH),arm)
-	BASEIMAGE?=k8s.gcr.io/debian-base-arm:v1.0.0
-endif
-ifeq ($(ARCH),arm64)
-	BASEIMAGE?=k8s.gcr.io/debian-base-arm64:v1.0.0
-endif
-ifeq ($(ARCH),ppc64le)
-	BASEIMAGE?=k8s.gcr.io/debian-base-ppc64le:v1.0.0
-endif
-ifeq ($(ARCH),s390x)
-	BASEIMAGE?=k8s.gcr.io/debian-base-s390x:v1.0.0
-endif
+BASEIMAGE ?= k8s.gcr.io/debian-base-$(ARCH):v2.0.0
 
 # These rules MUST be expanded at reference time (hence '=') as BINARY
 # is dynamically scoped.


### PR DESCRIPTION
Use --no-install-recommends to not install nftables as it depends on bash
(https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=956655)

Only build tested for amd64 for now
champtar/k8s-dns-sidecar-amd64         1.15.11-14-g423a2b4   b28aafaa2996
champtar/k8s-dns-node-cache-amd64      1.15.11-14-g423a2b4   bb1e2b6e0b09
champtar/k8s-dns-kube-dns-amd64        1.15.11-14-g423a2b4   943afc53b468
champtar/k8s-dns-dnsmasq-nanny-amd64   1.15.11-14-g423a2b4   28526da70d44
champtar/k8s-dns-dnsmasq-amd64         1.15.11-14-g423a2b4   a13a493a9883

Edit: update images