### PR TITLE
Set version variable in build script, if not set.

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -26,8 +26,8 @@ if [ -z "${ARCH}" ]; then
     exit 1
 fi
 if [ -z "${VERSION}" ]; then
-    echo "VERSION must be set"
-    exit 1
+    VERSION=$(git describe --tags --always --dirty)
+    echo "VERSION must be set, overriding to $VERSION"
 fi
 
 export CGO_ENABLED=0


### PR DESCRIPTION
This seems to be causing automated builds to fail.


When triggering the command manually with increased verbosity, I see the log:

```
ec448270508e: Pull completeDEBUG: Reading GCS logfile: 206 (read 162 bytes)65ba82af53f7: Pull completeDigest: sha256:09e47edb668c2cac8c0bbce113f2f72c97b1555d70546dff569c8b9b27fcebd3Status: Downloaded newer image for golang:1.11-alpineDEBUG: Reading GCS logfile: 206 (read 254 bytes)VERSION must be setmake[1]: *** [rules.mk:95: bin/amd64/dnsmasq-nanny] Error 1make: *** [rules.mk:67: push-amd64] Error 2ERRORERROR: build step 0 "gcr.io/k8s-testimages/gcb-docker-gcloud:v20190906-745fed4" failed: step exited with non-zero status: 2DEBUG: Reading GCS logfile: 416 (no new content; keep polling)
```
Command used:
```
gcloud builds submit --verbosity debug --config ~/src/k8s.io/dns/cloudbuild.yaml --substitutions _PULL_BASE_REF=master,_GIT_TAG=v20200415-1.15.11-15-g559ef88 --project k8s-staging-dns --gcs-log-dir gs://k8s-staging-dns-gcb/logs --gcs-source-staging-dir gs://k8s-staging-dns-gcb/source gs://k8s-staging-dns-gcb/source/359c61fb-2cdf-4a78-a750-75576fa0a0e6.tgz
```