### PR TITLE
Revert "Set version variable in build script, if not set."

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -26,8 +26,8 @@ if [ -z "${ARCH}" ]; then
     exit 1
 fi
 if [ -z "${VERSION}" ]; then
-    VERSION=$(git describe --tags --always --dirty)
-    echo "VERSION must be set, overriding to $VERSION"
+    echo "VERSION must be set"
+    exit 1
 fi
 
 export CGO_ENABLED=0


### PR DESCRIPTION
Reverts kubernetes/dns#371

This change is not required. cloudbuild needs to set the VERSION variable.