### PR TITLE
Add a VERSION env var in cloudbuild.

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -8,6 +8,7 @@ steps:
     env:
     - PROW_GIT_TAG=$_GIT_TAG
     - PULL_BASE_REF=$_PULL_BASE_REF
+    - VERSION=$_GIT_TAG
     args:
     - -c
     - |


### PR DESCRIPTION
This will be used to tag the new images. This will fix the "VERSION must be set" error that build scripts are seeing in https://k8s-testgrid.appspot.com/sig-network-dns#dns-push-images

/assign @MrHohn 