### PR TITLE
Add extra space in sha check command

### DIFF
--- a/images/dnsmasq/Makefile
+++ b/images/dnsmasq/Makefile
@@ -155,7 +155,7 @@ endif
 $(DNSMASQ_ARCHIVE):
 	@mkdir -p $(@D)
 	@curl -sSL $(DNSMASQ_URL) > $@
-	@echo "$(DNSMASQ_SHA256) $(DNSMASQ_ARCHIVE)" > $(@D)/sha256.txt
+	@echo "$(DNSMASQ_SHA256)  $(DNSMASQ_ARCHIVE)" > $(@D)/sha256.txt
 	@sha256sum -c $(@D)/sha256.txt
 
 .PHONY: containers


### PR DESCRIPTION
This is needed for the check to pass in sha256sum installed in Busybox.

Verified that the automated build works using the command:

```
 gcloud builds submit ~/src/k8s.io/dns --verbosity debug --config cloudbuild.yaml --substitutions _PULL_BASE_REF=master,_GIT_TAG=v20200416-1.15.12-2-g232a189 --project k8s-staging-dns --gcs-log-dir gs://k8s-staging-dns-gcb/logs --gcs-source-staging-dir gs://k8s-staging-dns-gcb/source
```
The build above succeeded.

Thanks to @listx for identifying the correct command to be used in the build environment!

/assign @MrHohn 