### PR TITLE
Nodecache ebtables option

### DIFF
--- a/Dockerfile.node-cache
+++ b/Dockerfile.node-cache
@@ -19,8 +19,10 @@ FROM ARG_FROM
 RUN apt-get update && apt-get install -y --no-install-recommends \
     iproute2 \
     iptables \
+    ebtables \
 && update-alternatives --set iptables /usr/sbin/iptables-legacy \
 && update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy \
+&& update-alternatives --set ebtables /usr/sbin/ebtables-legacy \
 && rm -rf /var/lib/apt/lists/*
 ADD bin/ARG_ARCH/ARG_BIN /ARG_BIN
 EXPOSE 53 53/udp

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -962,6 +962,17 @@
   pruneopts = "UT"
   revision = "326cf6c2d0e2d72b82e5014710f1b0cf1bacf3b4"
 
+[[projects]]
+  branch = "master"
+  digest = "1:19c16fb5fe0717482c86b3cfb5dfb6cc28a5c83b3604469caffc69c4c7b22488"
+  name = "k8s.io/utils"
+  packages = [
+    "exec",
+    "net/ebtables",
+  ]
+  pruneopts = "UT"
+  revision = "988ee3149bb2e41c01d6399ddafe7ff6a4949486"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
@@ -1018,6 +1029,8 @@
     "k8s.io/kubernetes/pkg/util/iptables",
     "k8s.io/kubernetes/pkg/util/logs",
     "k8s.io/kubernetes/pkg/version/prometheus",
+    "k8s.io/utils/exec",
+    "k8s.io/utils/net/ebtables",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/node-cache/main.go
+++ b/cmd/node-cache/main.go
@@ -63,6 +63,7 @@ func parseAndValidateFlags() (*app.ConfigParams, error) {
 	flag.DurationVar(&params.Interval, "syncinterval", 60, "interval(in seconds) to check for iptables rules")
 	flag.StringVar(&params.MetricsListenAddress, "metrics-listen-address", "0.0.0.0:9353", "address to serve metrics on")
 	flag.BoolVar(&params.SetupIptables, "setupiptables", true, "indicates whether iptables rules should be setup")
+	flag.BoolVar(&params.SetupEbtables, "setupebtables", false, "indicates whether ebtables rules should be setup")
 	flag.StringVar(&params.BaseCoreFile, "basecorefile", "/etc/coredns/Corefile.base", "Path to the template Corefile for node-cache")
 	flag.StringVar(&params.CoreFile, "corefile", "/etc/Corefile", "Path to the Corefile to be used by node-cache")
 	flag.StringVar(&params.KubednsCMPath, "kubednscm", "/etc/kube-dns", "Path where the kube-dns configmap will be mounted")

--- a/vendor/k8s.io/utils/LICENSE
+++ b/vendor/k8s.io/utils/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/k8s.io/utils/exec/README.md
+++ b/vendor/k8s.io/utils/exec/README.md
@@ -1,0 +1,5 @@
+# Exec
+
+This package provides an interface for `os/exec`. It makes it easier to mock
+and replace in tests, especially with the [FakeExec](testing/fake_exec.go)
+struct.

--- a/vendor/k8s.io/utils/exec/doc.go
+++ b/vendor/k8s.io/utils/exec/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package exec provides an injectable interface and implementations for running commands.
+package exec // import "k8s.io/utils/exec"

--- a/vendor/k8s.io/utils/exec/exec.go
+++ b/vendor/k8s.io/utils/exec/exec.go
@@ -1,0 +1,252 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package exec
+
+import (
+	"context"
+	"io"
+	osexec "os/exec"
+	"syscall"
+	"time"
+)
+
+// ErrExecutableNotFound is returned if the executable is not found.
+var ErrExecutableNotFound = osexec.ErrNotFound
+
+// Interface is an interface that presents a subset of the os/exec API. Use this
+// when you want to inject fakeable/mockable exec behavior.
+type Interface interface {
+	// Command returns a Cmd instance which can be used to run a single command.
+	// This follows the pattern of package os/exec.
+	Command(cmd string, args ...string) Cmd
+
+	// CommandContext returns a Cmd instance which can be used to run a single command.
+	//
+	// The provided context is used to kill the process if the context becomes done
+	// before the command completes on its own. For example, a timeout can be set in
+	// the context.
+	CommandContext(ctx context.Context, cmd string, args ...string) Cmd
+
+	// LookPath wraps os/exec.LookPath
+	LookPath(file string) (string, error)
+}
+
+// Cmd is an interface that presents an API that is very similar to Cmd from os/exec.
+// As more functionality is needed, this can grow. Since Cmd is a struct, we will have
+// to replace fields with get/set method pairs.
+type Cmd interface {
+	// Run runs the command to the completion.
+	Run() error
+	// CombinedOutput runs the command and returns its combined standard output
+	// and standard error. This follows the pattern of package os/exec.
+	CombinedOutput() ([]byte, error)
+	// Output runs the command and returns standard output, but not standard err
+	Output() ([]byte, error)
+	SetDir(dir string)
+	SetStdin(in io.Reader)
+	SetStdout(out io.Writer)
+	SetStderr(out io.Writer)
+	SetEnv(env []string)
+
+	// StdoutPipe and StderrPipe for getting the process' Stdout and Stderr as
+	// Readers
+	StdoutPipe() (io.ReadCloser, error)
+	StderrPipe() (io.ReadCloser, error)
+
+	// Start and Wait are for running a process non-blocking
+	Start() error
+	Wait() error
+
+	// Stops the command by sending SIGTERM. It is not guaranteed the
+	// process will stop before this function returns. If the process is not
+	// responding, an internal timer function will send a SIGKILL to force
+	// terminate after 10 seconds.
+	Stop()
+}
+
+// ExitError is an interface that presents an API similar to os.ProcessState, which is
+// what ExitError from os/exec is. This is designed to make testing a bit easier and
+// probably loses some of the cross-platform properties of the underlying library.
+type ExitError interface {
+	String() string
+	Error() string
+	Exited() bool
+	ExitStatus() int
+}
+
+// Implements Interface in terms of really exec()ing.
+type executor struct{}
+
+// New returns a new Interface which will os/exec to run commands.
+func New() Interface {
+	return &executor{}
+}
+
+// Command is part of the Interface interface.
+func (executor *executor) Command(cmd string, args ...string) Cmd {
+	return (*cmdWrapper)(osexec.Command(cmd, args...))
+}
+
+// CommandContext is part of the Interface interface.
+func (executor *executor) CommandContext(ctx context.Context, cmd string, args ...string) Cmd {
+	return (*cmdWrapper)(osexec.CommandContext(ctx, cmd, args...))
+}
+
+// LookPath is part of the Interface interface
+func (executor *executor) LookPath(file string) (string, error) {
+	return osexec.LookPath(file)
+}
+
+// Wraps exec.Cmd so we can capture errors.
+type cmdWrapper osexec.Cmd
+
+var _ Cmd = &cmdWrapper{}
+
+func (cmd *cmdWrapper) SetDir(dir string) {
+	cmd.Dir = dir
+}
+
+func (cmd *cmdWrapper) SetStdin(in io.Reader) {
+	cmd.Stdin = in
+}
+
+func (cmd *cmdWrapper) SetStdout(out io.Writer) {
+	cmd.Stdout = out
+}
+
+func (cmd *cmdWrapper) SetStderr(out io.Writer) {
+	cmd.Stderr = out
+}
+
+func (cmd *cmdWrapper) SetEnv(env []string) {
+	cmd.Env = env
+}
+
+func (cmd *cmdWrapper) StdoutPipe() (io.ReadCloser, error) {
+	r, err := (*osexec.Cmd)(cmd).StdoutPipe()
+	return r, handleError(err)
+}
+
+func (cmd *cmdWrapper) StderrPipe() (io.ReadCloser, error) {
+	r, err := (*osexec.Cmd)(cmd).StderrPipe()
+	return r, handleError(err)
+}
+
+func (cmd *cmdWrapper) Start() error {
+	err := (*osexec.Cmd)(cmd).Start()
+	return handleError(err)
+}
+
+func (cmd *cmdWrapper) Wait() error {
+	err := (*osexec.Cmd)(cmd).Wait()
+	return handleError(err)
+}
+
+// Run is part of the Cmd interface.
+func (cmd *cmdWrapper) Run() error {
+	err := (*osexec.Cmd)(cmd).Run()
+	return handleError(err)
+}
+
+// CombinedOutput is part of the Cmd interface.
+func (cmd *cmdWrapper) CombinedOutput() ([]byte, error) {
+	out, err := (*osexec.Cmd)(cmd).CombinedOutput()
+	return out, handleError(err)
+}
+
+func (cmd *cmdWrapper) Output() ([]byte, error) {
+	out, err := (*osexec.Cmd)(cmd).Output()
+	return out, handleError(err)
+}
+
+// Stop is part of the Cmd interface.
+func (cmd *cmdWrapper) Stop() {
+	c := (*osexec.Cmd)(cmd)
+
+	if c.Process == nil {
+		return
+	}
+
+	c.Process.Signal(syscall.SIGTERM)
+
+	time.AfterFunc(10*time.Second, func() {
+		if !c.ProcessState.Exited() {
+			c.Process.Signal(syscall.SIGKILL)
+		}
+	})
+}
+
+func handleError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	switch e := err.(type) {
+	case *osexec.ExitError:
+		return &ExitErrorWrapper{e}
+	case *osexec.Error:
+		if e.Err == osexec.ErrNotFound {
+			return ErrExecutableNotFound
+		}
+	}
+
+	return err
+}
+
+// ExitErrorWrapper is an implementation of ExitError in terms of os/exec ExitError.
+// Note: standard exec.ExitError is type *os.ProcessState, which already implements Exited().
+type ExitErrorWrapper struct {
+	*osexec.ExitError
+}
+
+var _ ExitError = &ExitErrorWrapper{}
+
+// ExitStatus is part of the ExitError interface.
+func (eew ExitErrorWrapper) ExitStatus() int {
+	ws, ok := eew.Sys().(syscall.WaitStatus)
+	if !ok {
+		panic("can't call ExitStatus() on a non-WaitStatus exitErrorWrapper")
+	}
+	return ws.ExitStatus()
+}
+
+// CodeExitError is an implementation of ExitError consisting of an error object
+// and an exit code (the upper bits of os.exec.ExitStatus).
+type CodeExitError struct {
+	Err  error
+	Code int
+}
+
+var _ ExitError = CodeExitError{}
+
+func (e CodeExitError) Error() string {
+	return e.Err.Error()
+}
+
+func (e CodeExitError) String() string {
+	return e.Err.Error()
+}
+
+// Exited is to check if the process has finished
+func (e CodeExitError) Exited() bool {
+	return true
+}
+
+// ExitStatus is for checking the error code
+func (e CodeExitError) ExitStatus() int {
+	return e.Code
+}

--- a/vendor/k8s.io/utils/inotify/LICENSE
+++ b/vendor/k8s.io/utils/inotify/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/k8s.io/utils/inotify/PATENTS
+++ b/vendor/k8s.io/utils/inotify/PATENTS
@@ -1,0 +1,22 @@
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.

--- a/vendor/k8s.io/utils/net/ebtables/ebtables.go
+++ b/vendor/k8s.io/utils/net/ebtables/ebtables.go
@@ -1,0 +1,222 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package ebtables allows to control the ebtables Linux-based bridging firewall.
+// Both chains and rules can be added, deleted and modified.
+// For ebtables specific documentation see: http://ebtables.netfilter.org/
+package ebtables
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	utilexec "k8s.io/utils/exec"
+)
+
+const (
+	cmdebtables = "ebtables"
+
+	// Flag to show full mac in output. The default representation omits leading zeroes.
+	fullMac = "--Lmac2"
+)
+
+// RulePosition is the rule position within a table
+type RulePosition string
+
+// Relative position for a new rule
+const (
+	Prepend RulePosition = "-I"
+	Append  RulePosition = "-A"
+)
+
+// Table is an Ebtables table type
+type Table string
+
+// Tables available in ebtables by default
+const (
+	TableNAT    Table = "nat"
+	TableFilter Table = "filter"
+	TableBroute Table = "broute"
+)
+
+// Chain is an Ebtables chain type
+type Chain string
+
+// Chains that are built-in in ebtables
+const (
+	ChainPostrouting Chain = "POSTROUTING"
+	ChainPrerouting  Chain = "PREROUTING"
+	ChainOutput      Chain = "OUTPUT"
+	ChainInput       Chain = "INPUT"
+	ChainBrouting    Chain = "BROUTING"
+)
+
+type operation string
+
+const (
+	opCreateChain operation = "-N"
+	opFlushChain  operation = "-F"
+	opDeleteChain operation = "-X"
+	opListChain   operation = "-L"
+	opAppendRule  operation = "-A"
+	opPrependRule operation = "-I"
+	opDeleteRule  operation = "-D"
+)
+
+// Interface for running ebtables commands.  Implementations must be goroutine-safe.
+type Interface interface {
+	// GetVersion returns the "X.Y.Z" semver string for ebtables.
+	GetVersion() (string, error)
+	// EnsureRule checks if the specified rule is present and, if not, creates it.  If the rule existed, return true.
+	// WARNING: ebtables does not provide check operation like iptables do. Hence we have to do a string match of args.
+	// Input args must follow the format and sequence of ebtables list output. Otherwise, EnsureRule will always create
+	// new rules and causing duplicates.
+	EnsureRule(position RulePosition, table Table, chain Chain, args ...string) (bool, error)
+	// DeleteRule checks if the specified rule is present and, if so, deletes it.
+	DeleteRule(table Table, chain Chain, args ...string) error
+	// EnsureChain checks if the specified chain is present and, if not, creates it.  If the rule existed, return true.
+	EnsureChain(table Table, chain Chain) (bool, error)
+	// DeleteChain deletes the specified chain.  If the chain did not exist, return error.
+	DeleteChain(table Table, chain Chain) error
+	// FlushChain flush the specified chain.  If the chain did not exist, return error.
+	FlushChain(table Table, chain Chain) error
+}
+
+// runner implements Interface in terms of exec("ebtables").
+type runner struct {
+	exec utilexec.Interface
+}
+
+// New returns a new Interface which will exec ebtables.
+func New(exec utilexec.Interface) Interface {
+	runner := &runner{
+		exec: exec,
+	}
+	return runner
+}
+
+func makeFullArgs(table Table, op operation, chain Chain, args ...string) []string {
+	return append([]string{"-t", string(table), string(op), string(chain)}, args...)
+}
+
+// getEbtablesVersionString runs "ebtables --version" to get the version string
+// in the form "X.X.X"
+func getEbtablesVersionString(exec utilexec.Interface) (string, error) {
+	// this doesn't access mutable state so we don't need to use the interface / runner
+	bytes, err := exec.Command(cmdebtables, "--version").CombinedOutput()
+	if err != nil {
+		return "", err
+	}
+	versionMatcher := regexp.MustCompile(`v([0-9]+\.[0-9]+\.[0-9]+)`)
+	match := versionMatcher.FindStringSubmatch(string(bytes))
+	if match == nil {
+		return "", fmt.Errorf("no ebtables version found in string: %s", bytes)
+	}
+	return match[1], nil
+}
+
+func (runner *runner) GetVersion() (string, error) {
+	return getEbtablesVersionString(runner.exec)
+}
+
+func (runner *runner) EnsureRule(position RulePosition, table Table, chain Chain, args ...string) (bool, error) {
+	var exist bool
+	fullArgs := makeFullArgs(table, opListChain, chain, fullMac)
+	out, err := runner.exec.Command(cmdebtables, fullArgs...).CombinedOutput()
+	if err != nil {
+		exist = false
+	} else {
+		exist = checkIfRuleExists(string(out), args...)
+	}
+	if !exist {
+		fullArgs = makeFullArgs(table, operation(position), chain, args...)
+		out, err := runner.exec.Command(cmdebtables, fullArgs...).CombinedOutput()
+		if err != nil {
+			return exist, fmt.Errorf("Failed to ensure rule: %v, output: %v", err, string(out))
+		}
+	}
+	return exist, nil
+}
+
+func (runner *runner) DeleteRule(table Table, chain Chain, args ...string) error {
+	var exist bool
+	fullArgs := makeFullArgs(table, opListChain, chain, fullMac)
+	out, err := runner.exec.Command(cmdebtables, fullArgs...).CombinedOutput()
+	if err != nil {
+		exist = false
+	} else {
+		exist = checkIfRuleExists(string(out), args...)
+	}
+
+	if !exist {
+		return nil
+	}
+	fullArgs = makeFullArgs(table, opDeleteRule, chain, args...)
+	out, err = runner.exec.Command(cmdebtables, fullArgs...).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("Failed to delete rule: %v, output: %s", err, out)
+	}
+	return nil
+}
+
+func (runner *runner) EnsureChain(table Table, chain Chain) (bool, error) {
+	exist := true
+
+	args := makeFullArgs(table, opListChain, chain)
+	_, err := runner.exec.Command(cmdebtables, args...).CombinedOutput()
+	if err != nil {
+		exist = false
+	}
+	if !exist {
+		args = makeFullArgs(table, opCreateChain, chain)
+		out, err := runner.exec.Command(cmdebtables, args...).CombinedOutput()
+		if err != nil {
+			return exist, fmt.Errorf("Failed to ensure %v chain: %v, output: %v", chain, err, string(out))
+		}
+	}
+	return exist, nil
+}
+
+// checkIfRuleExists takes the output of ebtables list chain and checks if the input rules exists
+// WARNING: checkIfRuleExists expects the input args matches the format and sequence of ebtables list output
+func checkIfRuleExists(listChainOutput string, args ...string) bool {
+	rule := strings.Join(args, " ")
+	for _, line := range strings.Split(listChainOutput, "\n") {
+		if strings.TrimSpace(line) == rule {
+			return true
+		}
+	}
+	return false
+}
+
+func (runner *runner) DeleteChain(table Table, chain Chain) error {
+	fullArgs := makeFullArgs(table, opDeleteChain, chain)
+	out, err := runner.exec.Command(cmdebtables, fullArgs...).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("Failed to delete %v chain %v: %v, output: %v", string(table), string(chain), err, string(out))
+	}
+	return nil
+}
+
+func (runner *runner) FlushChain(table Table, chain Chain) error {
+	fullArgs := makeFullArgs(table, opFlushChain, chain)
+	out, err := runner.exec.Command(cmdebtables, fullArgs...).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("Failed to flush %v chain %v: %v, output: %v", string(table), string(chain), err, string(out))
+	}
+	return nil
+}

--- a/vendor/k8s.io/utils/third_party/forked/golang/LICENSE
+++ b/vendor/k8s.io/utils/third_party/forked/golang/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2012 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/k8s.io/utils/third_party/forked/golang/PATENTS
+++ b/vendor/k8s.io/utils/third_party/forked/golang/PATENTS
@@ -1,0 +1,22 @@
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.


### PR DESCRIPTION
Add extra `ebtables` option to NodeLocalDNS to address issue related to Azure Kubernetes (AKS):

https://github.com/kubernetes/dns/issues/389

This option, when true (default is false), adds the following 2 ebtables rules to nodes when NodeLocalDNS is installed:

```
sudo ebtables -t broute -A BROUTING --ip-dst 169.254.20.10 -p IPv4 -j redirect
sudo ebtables -t broute -A BROUTING --ip-dst 10.0.0.10 -p IPv4 -j redirect  
```

where the 2 IPs are from the -localip argument passed to NodeLocalDNS.

The 2 rules are automatically removed during NodeLocalDNS tear down as it happens already for iptables rules. 