### PR TITLE
Bump debian base image to v2.1.2

### DIFF
--- a/rules.mk
+++ b/rules.mk
@@ -29,7 +29,7 @@ export VERSION
 SRC_DIRS := cmd pkg
 
 ALL_ARCH := amd64 arm arm64 ppc64le s390x
-BASEIMAGE ?= us.gcr.io/k8s-artifacts-prod/build-image/debian-base-$(ARCH):v2.1.0
+BASEIMAGE ?= us.gcr.io/k8s-artifacts-prod/build-image/debian-base-$(ARCH):v2.1.2
 
 # These rules MUST be expanded at reference time (hence '=') as BINARY
 # is dynamically scoped.


### PR DESCRIPTION
This should resolve https://github.com/kubernetes/dns/issues/386

Apt package diffs:
```
$ container-diff diff us.gcr.io/k8s-artifacts-prod/build-image/debian-base-amd64:v2.1.0 us.gcr.io/k8s-artifacts-prod/build-image/debian-base-amd64:v2.1.2 --type=apt

-----Apt-----

Packages found only in us.gcr.io/k8s-artifacts-prod/build-image/debian-base-amd64:v2.1.0: None

Packages found only in us.gcr.io/k8s-artifacts-prod/build-image/debian-base-amd64:v2.1.2: None

Version differences:
PACKAGE               IMAGE1 (us.gcr.io/k8s-artifacts-prod/build-image/debian-base-amd64:v2.1.0)        IMAGE2 (us.gcr.io/k8s-artifacts-prod/build-image/debian-base-amd64:v2.1.2)
-apt                  1.8.2, 4M                                                                         1.8.2.1, 4M
-base-files           10.3 deb10u3, 340K                                                                10.3 deb10u5, 340K
-libapt-pkg5.0        1.8.2, 3.2M                                                                       1.8.2.1, 3.2M
-libgnutls30          3.6.7-4 deb10u3, 2.6M                                                             3.6.7-4 deb10u5, 2.6M
-libsystemd0          241-7~deb10u3, 767K                                                               241-7~deb10u4, 768K
-libudev1             241-7~deb10u3, 258K                                                               241-7~deb10u4, 259K
-perl-base            5.28.1-6, 9.9M                                                                    5.28.1-6 deb10u1, 9.9M
```