### PR TITLE
Log warning if kube-dns-upstream is not found.

### DIFF
--- a/cmd/node-cache/app/cache_app.go
+++ b/cmd/node-cache/app/cache_app.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"fmt"
 	"os"
 
 	"k8s.io/dns/cmd/kube-dns/app/options"
@@ -273,7 +272,7 @@ func NewCacheApp(params *ConfigParams) (*CacheApp, error) {
 	c := &CacheApp{params: params, kubednsConfig: options.NewKubeDNSConfig()}
 	c.clusterDNSIP = net.ParseIP(os.ExpandEnv(toSvcEnv(params.UpstreamSvcName)))
 	if c.clusterDNSIP == nil {
-		return nil, fmt.Errorf("Unable to lookup IP address of Upstream service %s, env %s `%s`", params.UpstreamSvcName, toSvcEnv(params.UpstreamSvcName), os.ExpandEnv(toSvcEnv(params.UpstreamSvcName)))
+		clog.Warningf("Unable to lookup IP address of Upstream service %s, env %s `%s`", params.UpstreamSvcName, toSvcEnv(params.UpstreamSvcName), os.ExpandEnv(toSvcEnv(params.UpstreamSvcName)))
 	}
 	return c, nil
 }


### PR DESCRIPTION
For deployments where node-cache is non listening on kube-dns IP, the kube-dns-upstream
service is not relevant. This change adds a warning message instead of a fatal error.