### PR TITLE
Install ginkgo as part of travis install step.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,7 @@ services:
 install:
 - mkdir -p ${GOPATH}/src/k8s.io
 - ln -s `pwd` ${GOPATH}/src/k8s.io/dns
-- go get -v github.com/onsi/ginkgo/ginkgo
-- go get -v github.com/onsi/gomega
+- go install github.com/onsi/ginkgo/ginkgo
 - export PATH=$PATH:$HOME/gopath/bin
 
 script:
@@ -35,6 +34,4 @@ script:
 - make all-containers
 - bash test/e2e/sidecar/e2e.sh
 - sudo -v
-- rm -rf vendor/github.com/onsi/ginkgo/extensions/table
-- mv /go/src/github.com/onsi/ginkgo/extensions/table vendor/github.com/onsi/ginkgo/extensions
 - ginkgo test/e2e

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ services:
 install:
 - mkdir -p ${GOPATH}/src/k8s.io
 - ln -s `pwd` ${GOPATH}/src/k8s.io/dns
+- export GOPATH=$GOPATH:${GOPATH}/src/k8s.io/dns
 - go install github.com/onsi/ginkgo/ginkgo
 - export PATH=$PATH:$HOME/gopath/bin
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,11 +25,16 @@ services:
 install:
 - mkdir -p ${GOPATH}/src/k8s.io
 - ln -s `pwd` ${GOPATH}/src/k8s.io/dns
-- export GOPATH=$GOPATH:${GOPATH}/src/k8s.io/dns
-- go install github.com/onsi/ginkgo/ginkgo
+- GO111MODULE="off" go get -v -t ./...
+- GO111MODULE="off" go get golang.org/x/tools/cmd/cover
+- GO111MODULE="off" go get github.com/onsi/gomega
+- GO111MODULE="off" go install github.com/onsi/ginkgo/ginkgo
 - export PATH=$PATH:$HOME/gopath/bin
 
 script:
+- GO111MODULE="on" go mod tidy
+- diff -u <(echo -n) <(git diff go.mod)
+- diff -u <(echo -n) <(git diff go.sum)
 - make build
 - make test
 - make all-containers

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,10 +25,15 @@ services:
 install:
 - mkdir -p ${GOPATH}/src/k8s.io
 - ln -s `pwd` ${GOPATH}/src/k8s.io/dns
+- go get -v github.com/onsi/ginkgo/ginkgo
+- go get -v github.com/onsi/gomega
+- go get -v -t ./...
+- export PATH=$PATH:$HOME/gopath/bin
+
 script:
 - make build
 - make test
 - make all-containers
 - bash test/e2e/sidecar/e2e.sh
 - sudo -v
-- cd ${GOPATH}/src/k8s.io/dns && bin/amd64/ginkgo test/e2e
+- ginkgo test/e2e

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ language: go
 # https://github.com/travis-ci/travis-ci/issues/5448
 dist: trusty
 go:
-- 1.11.x
+- 1.13.x
 
 services:
 - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,4 +35,6 @@ script:
 - make all-containers
 - bash test/e2e/sidecar/e2e.sh
 - sudo -v
+- rm -rf vendor/github.com/onsi/ginkgo/extensions/table
+- mv /go/src/github.com/onsi/ginkgo/extensions/table vendor/github.com/onsi/ginkgo/extensions
 - ginkgo test/e2e

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ install:
 - ln -s `pwd` ${GOPATH}/src/k8s.io/dns
 - go get -v github.com/onsi/ginkgo/ginkgo
 - go get -v github.com/onsi/gomega
-- go get -v -t ./...
 - export PATH=$PATH:$HOME/gopath/bin
 
 script:

--- a/build/build.sh
+++ b/build/build.sh
@@ -45,4 +45,3 @@ go install                                                         \
     -installsuffix "static"                                        \
     -ldflags "-X ${PKG}/pkg/version.VERSION=${VERSION}"            \
     ./...                                                          \
-    ./vendor/...

--- a/cmd/ginkgo
+++ b/cmd/ginkgo
@@ -1,1 +1,0 @@
-../vendor/github.com/onsi/ginkgo/

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
 
-	"k8s.io/dns/cmd/ginkgo/config"
+	"github.com/onsi/ginkgo/config"
 	"k8s.io/dns/pkg/e2e"
 
 	"os"


### PR DESCRIPTION
Remove logic to build the binary.

Used the config documented in http://onsi.github.io/ginkgo/#ginkgo-and-continuous-integration