### PR TITLE
Update the compile image to debian v2.1.2

### DIFF
--- a/images/dnsmasq/Makefile
+++ b/images/dnsmasq/Makefile
@@ -29,7 +29,7 @@ export DOCKER_CLI_EXPERIMENTAL=enabled
 
 BASEIMAGE ?= us.gcr.io/k8s-artifacts-prod/build-image/debian-base-$(ARCH):v2.1.2
 ifeq ($(ARCH),amd64)
-	COMPILE_IMAGE := us.gcr.io/k8s-artifacts-prod/build-image/debian-base-$(ARCH):v2.1.0
+	COMPILE_IMAGE := us.gcr.io/k8s-artifacts-prod/build-image/debian-base-$(ARCH):v2.1.2
 else ifeq ($(ARCH),arm)
 	TRIPLE    ?= arm-linux-gnueabihf
 	QEMUARCH  := arm


### PR DESCRIPTION
Follow up from https://github.com/kubernetes/dns/pull/411

Verified that the images built correctly and start up:

```
./image-checks.sh 1.15.15-11-g90a259a gcr.io/pavithrar-k8s-dev

Verifying dnsmasq-nanny startup
Unable to find image 'gcr.io/pavithrar-k8s-dev/k8s-dns-dnsmasq-nanny:1.15.14' locally
1.15.14: Pulling from pavithrar-k8s-dev/k8s-dns-dnsmasq-nanny
Digest: sha256:7cc4fed7134eb27f580be1acb6b3492f840d8f6f21fde37b0d24c24c59f09988
Status: Downloaded newer image for gcr.io/pavithrar-k8s-dev/k8s-dns-dnsmasq-nanny:1.15.14
F1008 18:51:34.832546       1 nanny.go:220] dnsmasq exited: <nil>
goroutine 1 [running]:
k8s.io/dns/vendor/github.com/golang/glog.stacks(0xc000333100, 0xc000414000, 0x42, 0x95)
	/go/src/k8s.io/dns/vendor/github.com/golang/glog/glog.go:769 +0xd4
k8s.io/dns/vendor/github.com/golang/glog.(*loggingT).output(0x1d686c0, 0xc000000003, 0xc0006780b0, 0x1cfe8ed, 0x8, 0xdc, 0x0)
	/go/src/k8s.io/dns/vendor/github.com/golang/glog/glog.go:720 +0x329
k8s.io/dns/vendor/github.com/golang/glog.(*loggingT).printf(0x1d686c0, 0x3, 0x127e272, 0x12, 0xc00060fe08, 0x1, 0x1)
	/go/src/k8s.io/dns/vendor/github.com/golang/glog/glog.go:655 +0x14b
k8s.io/dns/vendor/github.com/golang/glog.Fatalf(0x127e272, 0x12, 0xc00060fe08, 0x1, 0x1)
	/go/src/k8s.io/dns/vendor/github.com/golang/glog/glog.go:1148 +0x67
k8s.io/dns/pkg/dnsmasq.RunNanny(0x13bc8e0, 0xc0003332c0, 0x127cd0d, 0x11, 0x1d89108, 0x0, 0x0, 0x0, 0x127af27, 0xf)
	/go/src/k8s.io/dns/pkg/dnsmasq/nanny.go:220 +0x564
main.main()
	/go/src/k8s.io/dns/cmd/dnsmasq-nanny/main.go:82 +0x240
```