### PR TITLE
check default kube-dns cm file path firstly

### DIFF
--- a/cmd/node-cache/app/configmap.go
+++ b/cmd/node-cache/app/configmap.go
@@ -3,6 +3,7 @@ package app
 import (
 	"bytes"
 	"io/ioutil"
+	"os"
 	"path"
 	"strings"
 	"text/template"
@@ -35,6 +36,7 @@ const (
 	UpstreamClusterDNSVar   = "__PILLAR__CLUSTER__DNS__"
 	LocalListenIPsVar       = "__PILLAR__LOCAL__DNS__"
 	LocalDNSServerVar       = "__PILLAR__DNS__SERVER__"
+	DefaultKubednsCMPath    = "/etc/kube-dns"
 )
 
 // stubDomainInfo contains all the parameters needed to compute
@@ -146,6 +148,12 @@ func (c *CacheApp) initDNSConfigSync() {
 	var syncList []*syncInfo
 	var kubeDNSChan, NodeLocalDNSChan <-chan *config.Config
 	initialKubeDNSConfig := &config.Config{}
+
+	if c.params.KubednsCMPath == "" {
+		if _, err := os.Stat(DefaultKubednsCMPath); !os.IsNotExist(err) {
+			c.params.KubednsCMPath = DefaultKubednsCMPath
+		}
+	}
 
 	if c.params.KubednsCMPath != "" {
 		c.kubednsConfig.ConfigDir = c.params.KubednsCMPath

--- a/cmd/node-cache/main.go
+++ b/cmd/node-cache/main.go
@@ -69,7 +69,7 @@ func parseAndValidateFlags() (*app.ConfigParams, error) {
 	flag.BoolVar(&params.SetupEbtables, "setupebtables", false, "indicates whether ebtables rules should be setup")
 	flag.StringVar(&params.BaseCoreFile, "basecorefile", "/etc/coredns/Corefile.base", "Path to the template Corefile for node-cache")
 	flag.StringVar(&params.CoreFile, "corefile", "/etc/Corefile", "Path to the Corefile to be used by node-cache")
-	flag.StringVar(&params.KubednsCMPath, "kubednscm", "/etc/kube-dns", "Path where the kube-dns configmap will be mounted")
+	flag.StringVar(&params.KubednsCMPath, "kubednscm", "", "Path where the kube-dns configmap will be mounted")
 	flag.StringVar(&params.UpstreamSvcName, "upstreamsvc", "kube-dns", "Service name whose cluster IP is upstream for node-cache")
 	flag.StringVar(&params.HealthPort, "health-port", "8080", "port used by health plugin")
 	flag.BoolVar(&params.SkipTeardown, "skipteardown", false, "indicates whether iptables rules should be torn down on exit")


### PR DESCRIPTION
For upgrade user, it is odd that the logs shows that /etc/kube-dns file missing.

Corefile is required, however, stubdomain is not.

So we should not set the /etc/kube-dns as the default value, we can check it and load it if it exists. 

That's why I add this pr.

### why not add it to main.go?

The kube-dns configmap mount is optional, and when we create it after the pod start, the file will appear after the config map is created. 