### PR TITLE
Add support hosts plugin for node-cache

### DIFF
--- a/cmd/node-cache/main.go
+++ b/cmd/node-cache/main.go
@@ -22,6 +22,7 @@ import (
 	_ "github.com/coredns/coredns/plugin/errors"
 	_ "github.com/coredns/coredns/plugin/forward"
 	_ "github.com/coredns/coredns/plugin/health"
+	_ "github.com/coredns/coredns/plugin/hosts"
 	_ "github.com/coredns/coredns/plugin/loadbalance"
 	_ "github.com/coredns/coredns/plugin/log"
 	_ "github.com/coredns/coredns/plugin/loop"


### PR DESCRIPTION
Add support [hosts](https://coredns.io/plugins/hosts/) plugin for node-cache.
It enable coredns's hosts plugin so user can add custom hosts to cluster.

Fixes kubernetes-sigs/kubespray/issues/6676