### PR TITLE
Add coredns trace plugin to node-cache.

### DIFF
--- a/cmd/node-cache/main.go
+++ b/cmd/node-cache/main.go
@@ -30,6 +30,7 @@ import (
 	_ "github.com/coredns/coredns/plugin/pprof"
 	_ "github.com/coredns/coredns/plugin/reload"
 	_ "github.com/coredns/coredns/plugin/template"
+	_ "github.com/coredns/coredns/plugin/trace"
 	_ "github.com/coredns/coredns/plugin/whoami"
 	"k8s.io/dns/pkg/version"
 )


### PR DESCRIPTION
Add trace coredns plugin to node-cache.

Fixes #423.