### PR TITLE
Upgrade to dnsmasq 2.83 to pick up vulnerability fix

### DIFF
--- a/images/dnsmasq/Makefile
+++ b/images/dnsmasq/Makefile
@@ -15,7 +15,7 @@
 VERSION ?= $(shell git describe --tags --always --dirty)
 REGISTRY ?= staging-k8s.gcr.io
 ARCH ?= amd64
-DNSMASQ_VERSION ?= dnsmasq-2.78
+DNSMASQ_VERSION ?= dnsmasq-2.83
 CONTAINER_PREFIX ?= k8s-dns
 
 ALL_ARCH := amd64 arm arm64 ppc64le s390x
@@ -50,14 +50,14 @@ DNSMASQ_URL := http://www.thekelleys.org.uk/dnsmasq/$(DNSMASQ_VERSION).tar.xz
 # SHA-256 computed from GPG-verified download:
 # $ gpg --recv 15CDDA6AE19135A2
 # ...
-# $ gpg --verify dnsmasq-2.78.tar.xz.asc dnsmasq-2.78.tar.xz
-# gpg: Signature made Mon 02 Oct 2017 06:40:03 AM PDT
-# gpg:                using RSA key 15CDDA6AE19135A2
+# $gpg --verify dnsmasq-2.83.tar.xz.asc dnsmasq-2.83.tar.xz
+# gpg: Signature made Tue 19 Jan 2021 01:47:31 AM PST
+# gpg:                using RSA key D6EACBD6EE46B834248D111215CDDA6AE19135A2
 # gpg: Good signature from "Simon Kelley <simon@thekelleys.org.uk>" [unknown]
 # gpg:                 aka "Simon Kelley <srk@debian.org>" [unknown]
 # ...
-# $ sha256sum dnsmasq-2.78.tar.xz
-DNSMASQ_SHA256 := 89949f438c74b0c7543f06689c319484bd126cc4b1f8c745c742ab397681252b
+# $ sha256sum dnsmasq-2.83.tar.xz
+DNSMASQ_SHA256 := ffc1f7e8b05e22d910b9a71d09f1128197292766dc7c54cb7018a1b2c3af4aea
 DNSMASQ_ARCHIVE := $(OUTPUT_DIR)/dnsmasq.tar.xz
 
 MULTIARCH_CONTAINER := multiarch/qemu-user-static:register


### PR DESCRIPTION
https://www.jsof-tech.com/disclosures/dnspooq

Verified that the images all come up correctly.

```
/image-checks.sh 1.16.0-18-g6f0a02c-dirty gcr.io/<repo>

1.16.0-18-g6f0a02c-dirty: Pulling from <repo>/k8s-dns-dnsmasq-nanny
Status: Downloaded newer image for gcr.io/<repo>/k8s-dns-dnsmasq-nanny:1.16.0-18-g6f0a02c-dirty
I0120 00:42:19.372813       1 main.go:78] opts: {{/usr/sbin/dnsmasq [] false} /etc/k8s/dns/dnsmasq-nanny 10000000000 127.0.0.1:10053}
I0120 00:42:19.373466       1 nanny.go:124] Starting dnsmasq []
W0120 00:42:19.390982       1 nanny.go:150] Got EOF from stdout
W0120 00:42:19.391000       1 nanny.go:150] Got EOF from stderr
F0120 00:42:19.391066       1 nanny.go:220] dnsmasq exited: <nil>


```