### PR TITLE
Increase build timeout to 1.5 hours.

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,7 +1,7 @@
 # See https://cloud.google.com/cloud-build/docs/build-config
 
 # this must be specified in seconds. If omitted, defaults to 600s (10 mins)
-timeout: 3600s
+timeout: 4500s
 steps:
   - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20190906-745fed4'
     entrypoint: bash


### PR DESCRIPTION
The previous build invocation failed due to timeout - https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/dns-push-images/1352431660452286464