### PR TITLE
Revert "Upgrade to dnsmasq 2.83 to pick up vulnerability fix"

### DIFF
--- a/images/dnsmasq/Makefile
+++ b/images/dnsmasq/Makefile
@@ -15,7 +15,7 @@
 VERSION ?= $(shell git describe --tags --always --dirty)
 REGISTRY ?= staging-k8s.gcr.io
 ARCH ?= amd64
-DNSMASQ_VERSION ?= dnsmasq-2.83
+DNSMASQ_VERSION ?= dnsmasq-2.78
 CONTAINER_PREFIX ?= k8s-dns
 
 ALL_ARCH := amd64 arm arm64 ppc64le s390x
@@ -50,14 +50,14 @@ DNSMASQ_URL := http://www.thekelleys.org.uk/dnsmasq/$(DNSMASQ_VERSION).tar.xz
 # SHA-256 computed from GPG-verified download:
 # $ gpg --recv 15CDDA6AE19135A2
 # ...
-# $gpg --verify dnsmasq-2.83.tar.xz.asc dnsmasq-2.83.tar.xz
-# gpg: Signature made Tue 19 Jan 2021 01:47:31 AM PST
-# gpg:                using RSA key D6EACBD6EE46B834248D111215CDDA6AE19135A2
+# $ gpg --verify dnsmasq-2.78.tar.xz.asc dnsmasq-2.78.tar.xz
+# gpg: Signature made Mon 02 Oct 2017 06:40:03 AM PDT
+# gpg:                using RSA key 15CDDA6AE19135A2
 # gpg: Good signature from "Simon Kelley <simon@thekelleys.org.uk>" [unknown]
 # gpg:                 aka "Simon Kelley <srk@debian.org>" [unknown]
 # ...
-# $ sha256sum dnsmasq-2.83.tar.xz
-DNSMASQ_SHA256 := ffc1f7e8b05e22d910b9a71d09f1128197292766dc7c54cb7018a1b2c3af4aea
+# $ sha256sum dnsmasq-2.78.tar.xz
+DNSMASQ_SHA256 := 89949f438c74b0c7543f06689c319484bd126cc4b1f8c745c742ab397681252b
 DNSMASQ_ARCHIVE := $(OUTPUT_DIR)/dnsmasq.tar.xz
 
 MULTIARCH_CONTAINER := multiarch/qemu-user-static:register


### PR DESCRIPTION
Reverts kubernetes/dns#431

Some DNS lookup errors have been reported in http://lists.thekelleys.org.uk/pipermail/dnsmasq-discuss/2021q1/014621.html

Will pick up the latest once the fixed version is available.