### PR TITLE
Update iptables and base images to buster-v1.6.0.

### DIFF
--- a/images/dnsmasq/Makefile
+++ b/images/dnsmasq/Makefile
@@ -27,9 +27,9 @@ OUTPUT_DIR := _output/$(ARCH)
 # Ensure that the docker command line supports the manifest images
 export DOCKER_CLI_EXPERIMENTAL=enabled
 
-BASEIMAGE ?= k8s.gcr.io/build-image/debian-base-$(ARCH):buster-v1.5.0
+BASEIMAGE ?= k8s.gcr.io/build-image/debian-base-$(ARCH):buster-v1.6.0
 ifeq ($(ARCH),amd64)
-	COMPILE_IMAGE := k8s.gcr.io/build-image/debian-base-$(ARCH):buster-v1.5.0
+	COMPILE_IMAGE := k8s.gcr.io/build-image/debian-base-$(ARCH):buster-v1.6.0
 else ifeq ($(ARCH),arm)
 	TRIPLE    ?= arm-linux-gnueabihf
 	QEMUARCH  := arm

--- a/rules.mk
+++ b/rules.mk
@@ -29,8 +29,8 @@ export VERSION
 SRC_DIRS := cmd pkg
 
 ALL_ARCH := amd64 arm arm64 ppc64le s390x
-BASEIMAGE ?= k8s.gcr.io/build-image/debian-base-$(ARCH):buster-v1.5.0
-IPTIMAGE ?= k8s.gcr.io/build-image/debian-iptables-$(ARCH):buster-v1.5.0
+BASEIMAGE ?= k8s.gcr.io/build-image/debian-base-$(ARCH):buster-v1.6.0
+IPTIMAGE ?= k8s.gcr.io/build-image/debian-iptables-$(ARCH):buster-v1.6.0
 
 # These rules MUST be expanded at reference time (hence '=') as BINARY
 # is dynamically scoped.


### PR DESCRIPTION
There are several vulnerabilty fixes betwen buster-v1.5.0 and
buster-v1.6.0.

Verified that all images start up using ./image-checks.sh