### PR TITLE
Avoid delaying startup by SyncInterval for initial iptables/ebtables setup

### DIFF
--- a/cmd/node-cache/app/cache_app.go
+++ b/cmd/node-cache/app/cache_app.go
@@ -28,6 +28,7 @@ type ConfigParams struct {
 	SetupInterface       bool          // Indicates whether to setup network interface
 	InterfaceName        string        // Name of the interface to be created
 	Interval             time.Duration // specifies how often to run iptables rules check
+	InitialDelay         time.Duration // specifies the initial delay before configuring iptables
 	BaseCoreFile         string        // Path to the template config file for node-cache
 	CoreFile             string        // Path to config file used by node-cache
 	KubednsCMPath        string        // Directory where kube-dns configmap will be mounted
@@ -271,6 +272,7 @@ func (c *CacheApp) setupNetworking() {
 func (c *CacheApp) runPeriodic() {
 	c.exitChan = make(chan struct{}, 1)
 	tick := time.NewTicker(c.params.Interval * time.Second)
+	time.Sleep(c.params.InitialDelay)
 	c.setupNetworking()
 	for {
 		select {

--- a/cmd/node-cache/app/cache_app.go
+++ b/cmd/node-cache/app/cache_app.go
@@ -273,7 +273,7 @@ func (c *CacheApp) runPeriodic() {
 	// if a pidfile is defined in flags, setup iptables as soon as it's created
 	if c.params.Pidfile != "" {
 		for {
-			if isFileExist(c.params.Pidfile) {
+			if isFileExists(c.params.Pidfile) {
 				break
 			}
 			clog.Infof("waiting for coredns pidfile '%s'", c.params.Pidfile)

--- a/cmd/node-cache/app/cache_app.go
+++ b/cmd/node-cache/app/cache_app.go
@@ -84,7 +84,7 @@ func (c *CacheApp) Init() {
 	c.updateCorefile(&config.Config{})
 	// Initialize periodic sync for node-local-dns, kube-dns configmap.
 	c.initDNSConfigSync()
-	// Setup only the network interface during this init. IPTables will be setup via runPeriodic.
+	// Setup only the network interface first.
 	// This is to ensure that iptables rules don't get setup if the cache(coreDNS) is unable to startup due to config
 	// error, port conflicts or other reasons.
 	c.setupInterface()

--- a/cmd/node-cache/app/cache_app.go
+++ b/cmd/node-cache/app/cache_app.go
@@ -87,10 +87,9 @@ func (c *CacheApp) Init() {
 	// Setup only the network interface during this init. IPTables will be setup via runPeriodic.
 	// This is to ensure that iptables rules don't get setup if the cache(coreDNS) is unable to startup due to config
 	// error, port conflicts or other reasons.
-	setupIptables := c.params.SetupIptables
-	c.params.SetupIptables = false
+	c.setupInterface()
+	// Initial setup of iptables/ebtables
 	c.setupNetworking()
-	c.params.SetupIptables = setupIptables
 }
 
 // isIPv6 return if the node-cache is working in IPv6 mode
@@ -252,6 +251,10 @@ func (c *CacheApp) setupNetworking() {
 		}
 	}
 
+	c.setupInterface()
+}
+
+func (c *CacheApp) setupInterface() {
 	if c.params.SetupInterface {
 		exists, err := c.netifHandle.EnsureDummyDevice(c.params.InterfaceName)
 		if !exists {

--- a/cmd/node-cache/app/cache_app_test.go
+++ b/cmd/node-cache/app/cache_app_test.go
@@ -42,7 +42,6 @@ cluster.local:53 {
     }
 `
 	templateCoreFileName   = "testCoreFile.base"
-	pidfileName            = "testCoredns.pid"
 	coreFileName           = "testCoreFile"
 	cmDirName              = "testKubeDNSDir"
 	stubDomainFileName     = "stubDomains"
@@ -81,11 +80,6 @@ func createBaseFiles(t *testing.T, p *ConfigParams) {
 	}
 	if err := os.Mkdir(p.KubednsCMPath, os.ModePerm); err != nil {
 		t.Fatalf("Failed to create KubeDNS configmap dir - %v", err)
-	}
-	if p.Pidfile != "" {
-		if err := ioutil.WriteFile(p.Pidfile, []byte("1"), os.ModePerm); err != nil {
-			t.Fatalf("Failed to write pidfile - %v", err)
-		}
 	}
 }
 
@@ -267,30 +261,4 @@ func TestUpdateIPv6CoreFile(t *testing.T) {
 	if !stubDomainsEqual(strings.TrimSpace(stubStr), strings.TrimSpace(expectedStubStr), t) {
 		t.Fail()
 	}
-}
-
-func TestFileWaiter(t *testing.T) {
-	baseDir, err := ioutil.TempDir("", "dnstest")
-	if err != nil {
-		t.Fatalf("Failed to obtain temp directory for testing, err %v", err)
-	}
-	c, err := NewCacheApp(&ConfigParams{
-		Pidfile:       filepath.Join(baseDir, pidfileName),
-		BaseCoreFile:  filepath.Join(baseDir, templateCoreFileName),
-		KubednsCMPath: filepath.Join(baseDir, cmDirName),
-	})
-	if err != nil {
-		t.Fatalf("Failed to obtain CacheApp instance, err %v", err)
-	}
-	createBaseFiles(t, c.params)
-	ok := waitForFile(c.params.Pidfile, time.Second*1, time.Millisecond*100)
-	if !ok {
-		t.Fail()
-	}
-	os.RemoveAll(baseDir)
-	ok = waitForFile(c.params.Pidfile, time.Second*1, time.Millisecond*100)
-	if ok {
-		t.Fail()
-	}
-
 }

--- a/cmd/node-cache/app/cache_app_test.go
+++ b/cmd/node-cache/app/cache_app_test.go
@@ -42,6 +42,7 @@ cluster.local:53 {
     }
 `
 	templateCoreFileName   = "testCoreFile.base"
+	pidfileName            = "testCoredns.pid"
 	coreFileName           = "testCoreFile"
 	cmDirName              = "testKubeDNSDir"
 	stubDomainFileName     = "stubDomains"
@@ -80,6 +81,11 @@ func createBaseFiles(t *testing.T, p *ConfigParams) {
 	}
 	if err := os.Mkdir(p.KubednsCMPath, os.ModePerm); err != nil {
 		t.Fatalf("Failed to create KubeDNS configmap dir - %v", err)
+	}
+	if p.Pidfile != "" {
+		if err := ioutil.WriteFile(p.Pidfile, []byte("1"), os.ModePerm); err != nil {
+			t.Fatalf("Failed to write pidfile - %v", err)
+		}
 	}
 }
 
@@ -261,4 +267,30 @@ func TestUpdateIPv6CoreFile(t *testing.T) {
 	if !stubDomainsEqual(strings.TrimSpace(stubStr), strings.TrimSpace(expectedStubStr), t) {
 		t.Fail()
 	}
+}
+
+func TestFileWaiter(t *testing.T) {
+	baseDir, err := ioutil.TempDir("", "dnstest")
+	if err != nil {
+		t.Fatalf("Failed to obtain temp directory for testing, err %v", err)
+	}
+	c, err := NewCacheApp(&ConfigParams{
+		Pidfile:       filepath.Join(baseDir, pidfileName),
+		BaseCoreFile:  filepath.Join(baseDir, templateCoreFileName),
+		KubednsCMPath: filepath.Join(baseDir, cmDirName),
+	})
+	if err != nil {
+		t.Fatalf("Failed to obtain CacheApp instance, err %v", err)
+	}
+	createBaseFiles(t, c.params)
+	ok := waitForFile(c.params.Pidfile, time.Second*1, time.Millisecond*100)
+	if !ok {
+		t.Fail()
+	}
+	os.RemoveAll(baseDir)
+	ok = waitForFile(c.params.Pidfile, time.Second*1, time.Millisecond*100)
+	if ok {
+		t.Fail()
+	}
+
 }

--- a/cmd/node-cache/main.go
+++ b/cmd/node-cache/main.go
@@ -67,7 +67,6 @@ func parseAndValidateFlags() (*app.ConfigParams, error) {
 	flag.BoolVar(&params.SetupInterface, "setupinterface", true, "indicates whether network interface should be setup")
 	flag.StringVar(&params.InterfaceName, "interfacename", "nodelocaldns", "name of the interface to be created")
 	flag.DurationVar(&params.Interval, "syncinterval", 60, "interval(in seconds) to check for iptables rules")
-	flag.DurationVar(&params.InitialDelay, "initialdelay", 10, "initial delay(in seconds) before configuring iptables")
 	flag.StringVar(&params.MetricsListenAddress, "metrics-listen-address", "0.0.0.0:9353", "address to serve metrics on")
 	flag.BoolVar(&params.SetupIptables, "setupiptables", true, "indicates whether iptables rules should be setup")
 	flag.BoolVar(&params.SetupEbtables, "setupebtables", false, "indicates whether ebtables rules should be setup")
@@ -108,6 +107,10 @@ func parseAndValidateFlags() (*app.ConfigParams, error) {
 	if f = flag.Lookup("conf"); f != nil {
 		params.CoreFile = f.Value.String()
 		clog.Infof("Using Corefile %s", params.CoreFile)
+	}
+	if f = flag.Lookup("pidfile"); f != nil {
+		params.Pidfile = f.Value.String()
+		clog.Infof("Using Pidfile %s", params.Pidfile)
 	}
 	return params, nil
 }

--- a/cmd/node-cache/main.go
+++ b/cmd/node-cache/main.go
@@ -67,6 +67,7 @@ func parseAndValidateFlags() (*app.ConfigParams, error) {
 	flag.BoolVar(&params.SetupInterface, "setupinterface", true, "indicates whether network interface should be setup")
 	flag.StringVar(&params.InterfaceName, "interfacename", "nodelocaldns", "name of the interface to be created")
 	flag.DurationVar(&params.Interval, "syncinterval", 60, "interval(in seconds) to check for iptables rules")
+	flag.DurationVar(&params.InitialDelay, "initialdelay", 10, "initial delay(in seconds) before configuring iptables")
 	flag.StringVar(&params.MetricsListenAddress, "metrics-listen-address", "0.0.0.0:9353", "address to serve metrics on")
 	flag.BoolVar(&params.SetupIptables, "setupiptables", true, "indicates whether iptables rules should be setup")
 	flag.BoolVar(&params.SetupEbtables, "setupebtables", false, "indicates whether ebtables rules should be setup")


### PR DESCRIPTION
Fixes #448 

This add an initial call to setupNetworking before we start the loop in order to avoid waiting SyncInterval for initial setup.