### PR TITLE
Increase build timeout to 2 hours.

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,7 +1,7 @@
 # See https://cloud.google.com/cloud-build/docs/build-config
 
 # this must be specified in seconds. If omitted, defaults to 600s (10 mins)
-timeout: 4500s
+timeout: 7200s
 steps:
   - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20190906-745fed4'
     entrypoint: bash


### PR DESCRIPTION
Current builds are failing due to timeout - https://k8s-testgrid.appspot.com/sig-network-dns#dns-push-images

/assign @MrHohn 