### PR TITLE
Increment error metric for rule deletion errors as well.

### DIFF
--- a/cmd/node-cache/app/metrics.go
+++ b/cmd/node-cache/app/metrics.go
@@ -34,6 +34,10 @@ func registerMetrics() {
 	setupErrCount.WithLabelValues("configmap").Add(0)
 }
 
+func publishErrorMetric(label string) {
+	setupErrCount.WithLabelValues(label).Inc()
+}
+
 func serveMetrics(ipport string) error {
 	ln, err := net.Listen("tcp", ipport)
 	if err != nil {


### PR DESCRIPTION
This will help identify any teardown errors when nodelocaldns pod is exiting.

No unit test since fake iptables in https://github.com/kubernetes/kubernetes/blob/master/pkg/util/iptables/testing/fake.go does not return error in any of the calls. This needs to be enhanced to verify error scenarios.

/assign @MrHohn 
/cc @rtheis