### PR TITLE
Upgrade to golang 1.17 to pick up CVE fix.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ REGISTRY ?= gcr.io/k8s-staging-dns
 # Default architecture to build for.
 ARCH ?= amd64
 # Image to use for building.
-BUILD_IMAGE ?= golang:1.16-alpine
+BUILD_IMAGE ?= golang:1.17-alpine
 # Containers will be named: $(CONTAINER_PREFIX)-$(BINARY)-$(ARCH):$(VERSION)
 CONTAINER_PREFIX ?= k8s-dns
 # Caching for go builds, disabled for CI

--- a/cmd/e2e/main.go
+++ b/cmd/e2e/main.go
@@ -69,7 +69,7 @@ start/stop containers on the local docker instance.
 
 func waitForSignal() {
 	log.Printf("Waiting for SIGINT, SIGTERM (use ctrl-c to stop cluster)")
-	ch := make(chan os.Signal)
+	ch := make(chan os.Signal, 1)
 	signal.Notify(ch, os.Interrupt, syscall.SIGTERM)
 	<-ch
 	log.Printf("Cleaning up")

--- a/cmd/kube-dns/app/server.go
+++ b/cmd/kube-dns/app/server.go
@@ -169,7 +169,7 @@ func (server *KubeDNSServer) setupHandlers() {
 // SIGTERM. This daemon will be killed by SIGKILL after the grace
 // period to allow for some manner of graceful shutdown.
 func setupSignalHandlers() {
-	sigChan := make(chan os.Signal)
+	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
 		for {

--- a/pkg/tools/tools.go
+++ b/pkg/tools/tools.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 package tools


### PR DESCRIPTION
https://access.redhat.com/security/cve/cve-2021-39293 - does not appear relevant to the DNS images, but upgrading as a best-practice.