### PR TITLE
Fail presubmit if any of the build commands fail.

### DIFF
--- a/presubmits.sh
+++ b/presubmits.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# Exit at the first failure.
+set -e
 # These are the commands run by the prow presubmit job.
 
 echo "installing ginkgo"


### PR DESCRIPTION
Current presubmit shows a "pass" status even if the build fails. Example - https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/dns/495/pull-kubernetes-dns-test/1473729632233590784