### PR TITLE
Upgrade baseimage and dnsmasq versions

### DIFF
--- a/images/dnsmasq/Makefile
+++ b/images/dnsmasq/Makefile
@@ -15,7 +15,7 @@
 VERSION ?= $(shell git describe --tags --always --dirty)
 REGISTRY ?= staging-k8s.gcr.io
 ARCH ?= amd64
-DNSMASQ_VERSION ?= dnsmasq-2.85
+DNSMASQ_VERSION ?= dnsmasq-2.86
 CONTAINER_PREFIX ?= k8s-dns
 
 ALL_ARCH := amd64 arm arm64 ppc64le s390x
@@ -27,9 +27,9 @@ OUTPUT_DIR := _output/$(ARCH)
 # Ensure that the docker command line supports the manifest images
 export DOCKER_CLI_EXPERIMENTAL=enabled
 
-BASEIMAGE ?= k8s.gcr.io/build-image/debian-base-$(ARCH):buster-v1.9.0
+BASEIMAGE ?= k8s.gcr.io/build-image/debian-base-$(ARCH):bullseye-v1.1.0
 ifeq ($(ARCH),amd64)
-	COMPILE_IMAGE := k8s.gcr.io/build-image/debian-base-$(ARCH):buster-v1.9.0
+	COMPILE_IMAGE := k8s.gcr.io/build-image/debian-base-$(ARCH):bullseye-v1.1.0
 else ifeq ($(ARCH),arm)
 	TRIPLE    ?= arm-linux-gnueabihf
 	QEMUARCH  := arm
@@ -50,14 +50,14 @@ DNSMASQ_URL := http://www.thekelleys.org.uk/dnsmasq/$(DNSMASQ_VERSION).tar.xz
 # SHA-256 computed from GPG-verified download:
 # $ gpg --recv 15CDDA6AE19135A2
 # ...
-# $ gpg --verify dnsmasq-2.85.tar.xz.asc dnsmasq-2.85.tar.xz
-# gpg: Signature made Wed 07 Apr 2021 08:41:31 PM UTC
+# $ gpg --verify dnsmasq-2.86.tar.xz.asc dnsmasq-2.86.tar.xz
+# gpg: Signature made Wed 08 Sep 2021 09:50:46 PM UTC
 # gpg:                using RSA key D6EACBD6EE46B834248D111215CDDA6AE19135A2
 # gpg: Good signature from "Simon Kelley <simon@thekelleys.org.uk>" [unknown]
 # gpg:                 aka "Simon Kelley <srk@debian.org>" [unknown]
 # ...
 # $ sha256sum dnsmasq-2.78.tar.xz
-DNSMASQ_SHA256 := ad98d3803df687e5b938080f3d25c628fe41c878752d03fbc6199787fee312fa
+DNSMASQ_SHA256 := 28d52cfc9e2004ac4f85274f52b32e1647b4dbc9761b82e7de1e41c49907eb08
 DNSMASQ_ARCHIVE := $(OUTPUT_DIR)/dnsmasq.tar.xz
 
 MULTIARCH_CONTAINER := multiarch/qemu-user-static:register
@@ -128,7 +128,7 @@ ifeq ($(ARCH),amd64)
 		$(COMPILE_IMAGE)              \
 		/bin/sh -c                    \
 		"apt-get update                           \
-			&& apt-get -y install build-essential libcap-dev \
+			&& apt-get -y install build-essential \
 			&& cd /build/$(DNSMASQ_VERSION)     \
 			&& make -j                          \
 			&& cp src/dnsmasq /build/docker/dnsmasq" $(VERBOSE_OUTPUT)

--- a/rules.mk
+++ b/rules.mk
@@ -29,8 +29,8 @@ export VERSION
 SRC_DIRS := cmd pkg
 
 ALL_ARCH := amd64 arm arm64 ppc64le s390x
-BASEIMAGE ?= k8s.gcr.io/build-image/debian-base-$(ARCH):buster-v1.9.0
-IPTIMAGE ?= k8s.gcr.io/build-image/debian-iptables-$(ARCH):buster-v1.6.7
+BASEIMAGE ?= k8s.gcr.io/build-image/debian-base-$(ARCH):bullseye-v1.1.0
+IPTIMAGE ?= k8s.gcr.io/build-image/debian-iptables-$(ARCH):bullseye-v1.2.0
 
 # These rules MUST be expanded at reference time (hence '=') as BINARY
 # is dynamically scoped.


### PR DESCRIPTION
Upgraded the baseimage to `bullseye-v1.1.0` for vuln fixes.

kk already uses such version https://github.com/kubernetes/kubernetes/blob/c571ebed14462b7b06d21d36fea23fa03e5a3526/build/dependencies.yaml#L117

Also updates dnsmasq to 2.86