### PR TITLE
Update cloudbuild.yaml to run docker buildx

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -9,6 +9,7 @@ steps:
     - PROW_GIT_TAG=$_GIT_TAG
     - PULL_BASE_REF=$_PULL_BASE_REF
     - VERSION=$_PULL_BASE_REF
+    - HOME=/root  # for docker buildx
     args:
     - -c
     - |

--- a/rules.mk
+++ b/rules.mk
@@ -141,8 +141,9 @@ $(foreach BINARY,$(CONTAINER_BINARIES),$(eval $(DOCKERFILE_RULE)))
 define CONTAINER_RULE
 .$(BUILDSTAMP_NAME)-container: bin/$(ARCH)/$(BINARY)
 	@echo "container: bin/$(ARCH)/$(BINARY) ($(CONTAINER_NAME))"
-	@docker build					\
-		$(DOCKER_BUILD_FLAGS)			\
+	@docker buildx build					\
+		--platform linux/$(ARCH)			\
+		$(DOCKER_BUILD_FLAGS)				\
 		-t $(CONTAINER_NAME):$(VERSION)		\
 		-f .$(BINARY)-$(ARCH)-dockerfile .	\
 		$(VERBOSE_OUTPUT)


### PR DESCRIPTION
In README https://github.com/kubernetes/test-infra/blob/b74506333229b4cecfddccded988e80f5742e4b3/config/jobs/image-pushing/README.md

it's said to set HOME var for the docker buildx build