### PR TITLE
Add docker auth command in cloudbuild to push images

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -14,7 +14,8 @@ steps:
     - -c
     - |
       echo "Building/Pushing DNS containers"
-      make all-push
+      gcloud auth configure-docker \
+      && make all-push
 substitutions:
   # _GIT_TAG will be filled with a git-based tag for the image, of the form vYYYYMMDD-hash, and
   # can be used as a substitution


### PR DESCRIPTION
From recent run:
https://storage.googleapis.com/kubernetes-jenkins/logs/dns-push-images/1549347853271306240/build-log.txt

```
pushing  : gcr.io/k8s-staging-dns/k8s-dns-dnsmasq-nanny-amd64:master
unauthorized: You don't have the needed permissions to perform this operation, and you may have invalid credentials. To authenticate your request, follow the steps in: https://cloud.google.com/container-registry/docs/advanced-authentication
make[1]: *** [rules.mk:165: .gcr.io_k8s-staging-dns_k8s-dns-dnsmasq-nanny-amd64_master-push] Error 1
```