### PR TITLE
Add extra config validation in node-local-cache config sync

### DIFF
--- a/cmd/node-cache/app/cache_app_test.go
+++ b/cmd/node-cache/app/cache_app_test.go
@@ -246,7 +246,7 @@ func TestUpdateIPv6CoreFile(t *testing.T) {
 	}
 	customConfig := &config.Config{StubDomains: map[string][]string{
 		"acme.local":   {"2001:db8:1:1:1::1"},
-		"google.local": {"8.8.8.8"},
+		"google.local": {"2001:4860:4860::8888"},
 		"widget.local": {"[2001:db8:2:2:2::2]:10053", "2001:db8:3:3:3::3"},
 	},
 		UpstreamNameservers: []string{"[2001:db8:2:2:2::2]:10053", "2001:db8:3:3:3::3"},

--- a/cmd/node-cache/app/cache_app_test.go
+++ b/cmd/node-cache/app/cache_app_test.go
@@ -170,7 +170,7 @@ func TestUpdateCoreFile(t *testing.T) {
 	}
 	customConfig := &config.Config{StubDomains: map[string][]string{
 		"acme.local":   {"1.1.1.1"},
-		"google.local": {"google-public-dns-a.google.com"},
+		"google.local": {"8.8.8.8"},
 		"widget.local": {"2.2.2.2:10053", "3.3.3.3"},
 	},
 		UpstreamNameservers: []string{"2.2.2.2:10053", "3.3.3.3"},
@@ -246,7 +246,7 @@ func TestUpdateIPv6CoreFile(t *testing.T) {
 	}
 	customConfig := &config.Config{StubDomains: map[string][]string{
 		"acme.local":   {"2001:db8:1:1:1::1"},
-		"google.local": {"google-public-dns-a.google.com"},
+		"google.local": {"8.8.8.8"},
 		"widget.local": {"[2001:db8:2:2:2::2]:10053", "2001:db8:3:3:3::3"},
 	},
 		UpstreamNameservers: []string{"[2001:db8:2:2:2::2]:10053", "2001:db8:3:3:3::3"},

--- a/cmd/node-cache/app/configmap.go
+++ b/cmd/node-cache/app/configmap.go
@@ -82,15 +82,15 @@ func getStubDomainStr(stubDomainMap map[string][]string, info *stubDomainInfo) s
 }
 
 func (c *CacheApp) updateCorefile(dnsConfig *config.Config) {
+	if err := dnsConfig.ValidateNodeLocalCacheConfig(); err != nil {
+		clog.Errorf("Invalid config: %v", err)
+		setupErrCount.WithLabelValues("configmap").Inc()
+		return
+	}
 	// construct part of the Corefile
 	baseConfig, err := ioutil.ReadFile(c.params.BaseCoreFile)
 	if err != nil {
 		clog.Errorf("Failed to read node-cache coreFile %s - %v", c.params.BaseCoreFile, err)
-		setupErrCount.WithLabelValues("configmap").Inc()
-		return
-	}
-	if err = dnsConfig.ValidateNodeLocalCacheConfig(); err != nil {
-		clog.Errorf("Invalid config: %v", err)
 		setupErrCount.WithLabelValues("configmap").Inc()
 		return
 	}

--- a/cmd/node-cache/app/configmap.go
+++ b/cmd/node-cache/app/configmap.go
@@ -89,6 +89,12 @@ func (c *CacheApp) updateCorefile(dnsConfig *config.Config) {
 		setupErrCount.WithLabelValues("configmap").Inc()
 		return
 	}
+	if err = dnsConfig.ValidateNodeLocalCacheConfig(); err != nil {
+		clog.Errorf("Invalid config: %v", err)
+		setupErrCount.WithLabelValues("configmap").Inc()
+		return
+	}
+
 	stubDomainStr := getStubDomainStr(dnsConfig.StubDomains, &stubDomainInfo{Port: c.params.LocalPort, CacheTTL: defaultTTL,
 		LocalIP: strings.Replace(c.params.LocalIPStr, ",", " ", -1)})
 	upstreamServers := strings.Join(dnsConfig.UpstreamNameservers, " ")

--- a/pkg/dns/config/config.go
+++ b/pkg/dns/config/config.go
@@ -141,7 +141,7 @@ func (config *Config) ValidateNodeLocalCacheConfig() error {
 		}
 	}
 	if err := validateForwardProxy(config.UpstreamNameservers...); err != nil {
-		return err
+		return fmt.Errorf("invalid upstream nameservers %s: %v", config.UpstreamNameservers, err)
 	}
 	return nil
 }

--- a/pkg/dns/config/config.go
+++ b/pkg/dns/config/config.go
@@ -22,7 +22,6 @@ import (
 	"strconv"
 
 	"github.com/coredns/coredns/plugin/pkg/parse"
-
 	types "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation"
 	fed "k8s.io/dns/pkg/dns/federation"
@@ -136,9 +135,9 @@ func (config *Config) validateUpstreamNameserver() error {
 // ValidateNodeLocalCacheConfig returns nil if the config can be compiled
 // to a valid Corefile.
 func (config *Config) ValidateNodeLocalCacheConfig() error {
-	for _, stubDomains := range config.StubDomains {
-		if err := validateForwardProxy(stubDomains...); err != nil {
-			return err
+	for domain, nameservers := range config.StubDomains {
+		if err := validateForwardProxy(nameservers...); err != nil {
+			return fmt.Errorf("invalid nameservers %s for the stub domain %s: %v", nameservers, domain, err)
 		}
 	}
 	if err := validateForwardProxy(config.UpstreamNameservers...); err != nil {

--- a/pkg/dns/config/config_test.go
+++ b/pkg/dns/config/config_test.go
@@ -64,3 +64,45 @@ func TestValidate(t *testing.T) {
 		assert.NotNil(t, err, "should not be valid: %+v", testCase)
 	}
 }
+
+func TestValidateNodeLocalCacheConfig(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		config    Config
+		wantError bool
+	}{
+		{
+			name:   "empty config",
+			config: Config{},
+		},
+		{
+			name: "valid config",
+			config: Config{
+				StubDomains:         map[string][]string{"": {"1.1.1.1"}},
+				UpstreamNameservers: []string{"1.1.1.1", "2.2.2.2"},
+			},
+		},
+		{
+			name: "invalid config: FQDN stub domain",
+			config: Config{
+				StubDomains:         map[string][]string{"": {"cluster.local"}},
+				UpstreamNameservers: []string{"1.1.1.1", "2.2.2.2"},
+			},
+			wantError: true,
+		},
+		{
+			name: "invalid config: FQDN upstream name server",
+			config: Config{
+				StubDomains:         map[string][]string{"": {"1.1.1.1"}},
+				UpstreamNameservers: []string{"1.1.1.1", "cluster.local"},
+			},
+			wantError: true,
+		},
+	} {
+		err := tc.config.ValidateNodeLocalCacheConfig()
+		gotError := err != nil
+		if gotError != tc.wantError {
+			t.Fatalf("ValidateNodeLocalCacheConfig(%v) got error = %v, want = %v", tc.config, gotError, tc.wantError)
+		}
+	}
+}


### PR DESCRIPTION
The validation is ported from the CoreDNS plugin forward: https://github.com/coredns/coredns/blob/fc7f3835d506960364b21cf62116a70eb8f4caf2/plugin/forward/setup.go#L97

TESTED= make bulid; make containers; make test (with the broken validate_dynamic_deps.py skipped)
Fix: #539 