### PR TITLE
refactor: move from io/ioutil to io and os packages

### DIFF
--- a/cmd/node-cache/app/cache_app_test.go
+++ b/cmd/node-cache/app/cache_app_test.go
@@ -15,7 +15,6 @@ package app
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -66,7 +65,7 @@ func updateStubDomainsAndUpstreamServers(t *testing.T, p *ConfigParams, c *confi
 	if stubDomainBlob, err := json.Marshal(c.StubDomains); err != nil {
 		t.Errorf("Failed to marshal stubdomains info, err %v", err)
 	} else {
-		if err := ioutil.WriteFile(filepath.Join(p.KubednsCMPath, stubDomainFileName), stubDomainBlob, os.ModePerm); err != nil {
+		if err := os.WriteFile(filepath.Join(p.KubednsCMPath, stubDomainFileName), stubDomainBlob, os.ModePerm); err != nil {
 			t.Errorf("Failed to write stubDomains file - %s, err %v", stubDomainFileName, err)
 		}
 	}
@@ -74,7 +73,7 @@ func updateStubDomainsAndUpstreamServers(t *testing.T, p *ConfigParams, c *confi
 	if upstreamBlob, err := json.Marshal(c.UpstreamNameservers); err != nil {
 		t.Errorf("Failed to marshal upstream nameservers info, err %v", err)
 	} else {
-		if err = ioutil.WriteFile(filepath.Join(p.KubednsCMPath, upstreamServerFileName), upstreamBlob, os.ModePerm); err != nil {
+		if err = os.WriteFile(filepath.Join(p.KubednsCMPath, upstreamServerFileName), upstreamBlob, os.ModePerm); err != nil {
 			t.Errorf("Failed to write stubDomains file - %s, err %v", upstreamServerFileName, err)
 		}
 	}
@@ -82,13 +81,13 @@ func updateStubDomainsAndUpstreamServers(t *testing.T, p *ConfigParams, c *confi
 }
 
 func updateBaseFile(t *testing.T, p *ConfigParams, newContents []byte) {
-	if err := ioutil.WriteFile(p.BaseCoreFile, []byte(newContents), os.ModePerm); err != nil {
+	if err := os.WriteFile(p.BaseCoreFile, []byte(newContents), os.ModePerm); err != nil {
 		t.Fatalf("Failed to update template config file - %v", err)
 	}
 }
 
 func createBaseFiles(t *testing.T, p *ConfigParams) {
-	if err := ioutil.WriteFile(p.BaseCoreFile, []byte(templateCoreFileContents), os.ModePerm); err != nil {
+	if err := os.WriteFile(p.BaseCoreFile, []byte(templateCoreFileContents), os.ModePerm); err != nil {
 		t.Fatalf("Failed to write template config file - %v", err)
 	}
 	if err := os.Mkdir(p.KubednsCMPath, os.ModePerm); err != nil {
@@ -97,7 +96,7 @@ func createBaseFiles(t *testing.T, p *ConfigParams) {
 }
 
 func compareFileContents(filename, contents string, t *testing.T) (string, int) {
-	out, err := ioutil.ReadFile(filename)
+	out, err := os.ReadFile(filename)
 	if err != nil {
 		t.Errorf("Failed to read file %s , err %v", filename, err)
 		return "", -1
@@ -125,13 +124,9 @@ func stubDomainsEqual(str1, str2 string, t *testing.T) bool {
 }
 
 func TestUpdateCoreFile(t *testing.T) {
-	baseDir, err := ioutil.TempDir("", "dnstest")
-	if err != nil {
-		t.Fatalf("Failed to obtain temp directory for testing, err %v", err)
-	}
+	baseDir := t.TempDir()
 	envName := strings.ToUpper(strings.Replace(UpstreamClusterDNS, "-", "_", -1)) + "_SERVICE_HOST"
 	os.Setenv(envName, "9.10.11.12")
-	defer func() { os.RemoveAll(baseDir) }()
 	c, err := NewCacheApp(&ConfigParams{LocalIPStr: "169.254.20.10,10.0.0.10",
 		LocalPort:       "53",
 		BaseCoreFile:    filepath.Join(baseDir, templateCoreFileName),
@@ -201,13 +196,9 @@ func TestUpdateCoreFile(t *testing.T) {
 }
 
 func TestUpdateIPv6CoreFile(t *testing.T) {
-	baseDir, err := ioutil.TempDir("", "dnstest")
-	if err != nil {
-		t.Fatalf("Failed to obtain temp directory for testing, err %v", err)
-	}
+	baseDir := t.TempDir()
 	envName := strings.ToUpper(strings.Replace(UpstreamClusterDNS, "-", "_", -1)) + "_SERVICE_HOST"
 	os.Setenv(envName, "2001:db8::1")
-	defer func() { os.RemoveAll(baseDir) }()
 	c, err := NewCacheApp(&ConfigParams{LocalIPStr: "fe80:169:254::1,fd00:1:2:3::5",
 		LocalPort:       "53",
 		BaseCoreFile:    filepath.Join(baseDir, templateCoreFileName),

--- a/cmd/node-cache/app/configmap.go
+++ b/cmd/node-cache/app/configmap.go
@@ -15,7 +15,6 @@ package app
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -88,7 +87,7 @@ func (c *CacheApp) updateCorefile(dnsConfig *config.Config) {
 		return
 	}
 	// construct part of the Corefile
-	baseConfig, err := ioutil.ReadFile(c.params.BaseCoreFile)
+	baseConfig, err := os.ReadFile(c.params.BaseCoreFile)
 	if err != nil {
 		clog.Errorf("Failed to read node-cache coreFile %s - %v", c.params.BaseCoreFile, err)
 		setupErrCount.WithLabelValues("configmap").Inc()
@@ -126,7 +125,7 @@ func (c *CacheApp) updateCorefile(dnsConfig *config.Config) {
 	newConfig := bytes.Buffer{}
 	newConfig.WriteString(string(baseConfig))
 	newConfig.WriteString(stubDomainStr)
-	if err := ioutil.WriteFile(c.params.CoreFile, newConfig.Bytes(), 0666); err != nil {
+	if err := os.WriteFile(c.params.CoreFile, newConfig.Bytes(), 0666); err != nil {
 		clog.Errorf("Failed to write config file %s - err %v", c.params.CoreFile, err)
 		setupErrCount.WithLabelValues("configmap").Inc()
 		return

--- a/cmd/sidecar-e2e/main.go
+++ b/cmd/sidecar-e2e/main.go
@@ -19,7 +19,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -211,7 +210,7 @@ func (h *harness) runTests() {
 func (h *harness) validate() int {
 	var errors []error
 
-	text, err := ioutil.ReadFile(h.tmpDir + "/metrics.log")
+	text, err := os.ReadFile(h.tmpDir + "/metrics.log")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -416,7 +415,7 @@ func (t *test) waitForMetrics() {
 			}
 
 			defer response.Body.Close()
-			buf, err := ioutil.ReadAll(response.Body)
+			buf, err := io.ReadAll(response.Body)
 			if err != nil {
 				log.Fatal(err)
 			}
@@ -455,7 +454,7 @@ func (t *test) getMetrics() {
 	}
 
 	defer response.Body.Close()
-	buf, err := ioutil.ReadAll(response.Body)
+	buf, err := io.ReadAll(response.Body)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -467,7 +466,7 @@ func (t *test) dump() {
 	defer t.lock.Unlock()
 
 	dumpOutput := func(name string, output string) {
-		err := ioutil.WriteFile(
+		err := os.WriteFile(
 			fmt.Sprintf("%v/%v.log", opts.outputDir, name),
 			[]byte(output), 0644)
 		if err != nil {
@@ -500,7 +499,7 @@ func main() {
 
 	switch opts.mode {
 	case "harness":
-		tmpdir, err := ioutil.TempDir("", "k8s-dns-sidecar-e2e")
+		tmpdir, err := os.MkdirTemp("", "k8s-dns-sidecar-e2e")
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/pkg/dns/config/sync_dir.go
+++ b/pkg/dns/config/sync_dir.go
@@ -19,7 +19,6 @@ package config
 import (
 	"crypto/sha256"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -99,7 +98,7 @@ func (syncSource *kubeFileSyncSource) load() (syncResult, error) {
 		if strings.HasPrefix(filename, ".") {
 			return nil
 		}
-		filedata, err := ioutil.ReadFile(path)
+		filedata, err := os.ReadFile(path)
 		if err != nil {
 			return err
 		}

--- a/pkg/dns/config/sync_dir_test.go
+++ b/pkg/dns/config/sync_dir_test.go
@@ -17,27 +17,19 @@ limitations under the License.
 package config
 
 import (
+	"crypto/sha256"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
 	"time"
 
-	"os"
-
-	"crypto/sha256"
-
 	"k8s.io/apimachinery/pkg/util/clock"
 )
 
 func TestSyncFile(t *testing.T) {
-
-	testParentDir, err := ioutil.TempDir("", "test.filesyncsource")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() { os.RemoveAll(testParentDir) }()
+	testParentDir := t.TempDir()
 
 	testDir := filepath.Join(testParentDir, "datadir")
 
@@ -66,10 +58,10 @@ func TestSyncFile(t *testing.T) {
 	if err := os.Mkdir(filepath.Join(testDir, "subdir"), os.FileMode(0755)); err != nil {
 		t.Fatal(err)
 	}
-	if err := ioutil.WriteFile(filepath.Join(testDir, "subdir", "subdirfile"), []byte("test"), os.FileMode(0755)); err != nil {
+	if err := os.WriteFile(filepath.Join(testDir, "subdir", "subdirfile"), []byte("test"), os.FileMode(0755)); err != nil {
 		t.Fatal(err)
 	}
-	if err := ioutil.WriteFile(filepath.Join(testDir, ".hiddenfile"), []byte("test"), os.FileMode(0755)); err != nil {
+	if err := os.WriteFile(filepath.Join(testDir, ".hiddenfile"), []byte("test"), os.FileMode(0755)); err != nil {
 		t.Fatal(err)
 	}
 	result, err = source.Once()
@@ -82,7 +74,7 @@ func TestSyncFile(t *testing.T) {
 
 	// should return error if non-utf8 data is encountered
 	// https://en.wikipedia.org/wiki/UTF-8#Codepage_layout
-	if err := ioutil.WriteFile(filepath.Join(testDir, "binary"), []byte{192}, os.FileMode(0755)); err != nil {
+	if err := os.WriteFile(filepath.Join(testDir, "binary"), []byte{192}, os.FileMode(0755)); err != nil {
 		t.Fatal(err)
 	}
 	result, err = source.Once()
@@ -93,10 +85,10 @@ func TestSyncFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := ioutil.WriteFile(filepath.Join(testDir, "file1"), []byte("data1"), os.FileMode(0755)); err != nil {
+	if err := os.WriteFile(filepath.Join(testDir, "file1"), []byte("data1"), os.FileMode(0755)); err != nil {
 		t.Fatal(err)
 	}
-	if err := ioutil.WriteFile(filepath.Join(testDir, "file2"), []byte("data2"), os.FileMode(0755)); err != nil {
+	if err := os.WriteFile(filepath.Join(testDir, "file2"), []byte("data2"), os.FileMode(0755)); err != nil {
 		t.Fatal(err)
 	}
 	result, err = source.Once()
@@ -146,7 +138,7 @@ func TestSyncFile(t *testing.T) {
 	if err := os.Remove(filepath.Join(testDir, "file1")); err != nil {
 		t.Fatal(err)
 	}
-	if err := ioutil.WriteFile(filepath.Join(testDir, "file3"), []byte("data3"), os.FileMode(0755)); err != nil {
+	if err := os.WriteFile(filepath.Join(testDir, "file3"), []byte("data3"), os.FileMode(0755)); err != nil {
 		t.Fatal(err)
 	}
 	expectedResult = syncResult{

--- a/pkg/dns/dns_test.go
+++ b/pkg/dns/dns_test.go
@@ -18,7 +18,6 @@ package dns
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -836,10 +835,8 @@ func TestConfigSyncInitialMap(t *testing.T) {
 }
 
 func TestUpdateConfig(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "test")
+	tmpdir := t.TempDir()
 	defaultResolvFile = filepath.Join(tmpdir, "resolv.conf")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
 
 	kd := newKubeDNS()
 	kd.SkyDNSConfig = new(skyserver.Config)
@@ -849,7 +846,7 @@ func TestUpdateConfig(t *testing.T) {
 	assert.NotEqual(t, nextConfig, kd.config)
 	assert.Equal(t, []string{}, kd.SkyDNSConfig.Nameservers)
 
-	err = ioutil.WriteFile(defaultResolvFile, []byte("nameserver 127.0.0.1"), 0666)
+	err := os.WriteFile(defaultResolvFile, []byte("nameserver 127.0.0.1"), 0666)
 	require.NoError(t, err)
 
 	kd.updateConfig(nextConfig)

--- a/pkg/e2e/dnsmasq/nanny.go
+++ b/pkg/e2e/dnsmasq/nanny.go
@@ -18,7 +18,6 @@ package dnsmasq
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -50,7 +49,7 @@ func (h *Harness) Configure(stubDomains string, upstreamNameservers string) {
 			if err := os.Remove(filename); err != nil {
 				panic(err)
 			}
-		} else if err := ioutil.WriteFile(filename, []byte(value), 0644); err != nil {
+		} else if err := os.WriteFile(filename, []byte(value), 0644); err != nil {
 			panic(err)
 		}
 	}
@@ -60,7 +59,7 @@ func (h *Harness) Configure(stubDomains string, upstreamNameservers string) {
 }
 
 func (h *Harness) readOutput() []string {
-	bytes, err := ioutil.ReadFile(h.TmpDir + "/args.txt")
+	bytes, err := os.ReadFile(h.TmpDir + "/args.txt")
 	if err != nil {
 		return []string{}
 	}

--- a/test/e2e/kubedns/kubedns.go
+++ b/test/e2e/kubedns/kubedns.go
@@ -18,7 +18,6 @@ package kubedns
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -79,17 +78,17 @@ var _ = Describe("kube-dns", func() {
 		if err := os.MkdirAll(configDir, 0744); err == nil {
 			om.Expect(err).NotTo(om.HaveOccurred())
 		}
-		if err := ioutil.WriteFile(configDir+"/upstreamNameservers", []byte("[\"127.0.0.1:10054\"]"), 0744); err != nil {
+		if err := os.WriteFile(configDir+"/upstreamNameservers", []byte("[\"127.0.0.1:10054\"]"), 0744); err != nil {
 			om.Expect(err).NotTo(om.HaveOccurred())
 		}
 		dnsmasqConfigDir := workDir + "/dnsmasq-config"
 		if err := os.MkdirAll(dnsmasqConfigDir, 0744); err != nil {
 			om.Expect(err).NotTo(om.HaveOccurred())
 		}
-		if err := ioutil.WriteFile(dnsmasqConfigDir+"/dnsmasq.conf", []byte("user=root\naddn-hosts=/etc/dnsmasq-hosts"), 0744); err != nil {
+		if err := os.WriteFile(dnsmasqConfigDir+"/dnsmasq.conf", []byte("user=root\naddn-hosts=/etc/dnsmasq-hosts"), 0744); err != nil {
 			om.Expect(err).NotTo(om.HaveOccurred())
 		}
-		if err := ioutil.WriteFile(dnsmasqConfigDir+"/dnsmasq-hosts", []byte("192.0.2.123 my.test"), 0744); err != nil {
+		if err := os.WriteFile(dnsmasqConfigDir+"/dnsmasq-hosts", []byte("192.0.2.123 my.test"), 0744); err != nil {
 			om.Expect(err).NotTo(om.HaveOccurred())
 		}
 		fr.Docker.Pull(fr.Options.DnsmasqImage)
@@ -127,7 +126,7 @@ var _ = Describe("kube-dns", func() {
 			fr.Docker.Kill(dnsmasq)
 		}()
 		By("Configuring upstream nameserver")
-		if err := ioutil.WriteFile(configDir+"/upstreamNameservers", []byte("[\"127.0.0.1:10055\"]"), 0744); err != nil {
+		if err := os.WriteFile(configDir+"/upstreamNameservers", []byte("[\"127.0.0.1:10055\"]"), 0744); err != nil {
 			om.Expect(err).NotTo(om.HaveOccurred())
 		}
 

--- a/third_party/forked/skydns/server/metrics_test.go
+++ b/third_party/forked/skydns/server/metrics_test.go
@@ -6,7 +6,7 @@ package server
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"testing"
@@ -29,7 +29,7 @@ func scrape(t *testing.T, key string) int {
 		return -1
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return -1
 	}


### PR DESCRIPTION
The `io/ioutil` package has been deprecated in Go 1.16 (See https://pkg.go.dev/io/ioutil). This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.

- `ioutil.Discard` => `io.Discard`
- `ioutil.NopCloser` => `io.NopCloser`
- `ioutil.ReadAll` => `io.ReadAll`
- `ioutil.ReadDir` => `os.ReadDir`
- `ioutil.ReadFile` => `os.ReadFile`
- `ioutil.TempDir` => `os.MkdirTemp`
- `ioutil.TempFile` => `os.CreateTemp`
- `ioutil.WriteFile` => `os.WriteFile`

`ioutil.TempDir` in `*_test.go` files can be replaced with `t.TempDir` from the `testing` package. The directory created by `t.TempDir` is automatically removed when the test and all its subtests complete. 

Reference: https://pkg.go.dev/testing#T.TempDir