### PR TITLE
Switch distroless-iptables to gke-release

### DIFF
--- a/rules.mk
+++ b/rules.mk
@@ -32,7 +32,7 @@ ALL_ARCH := amd64 arm arm64 ppc64le s390x
 # Multiarch image
 # Uploaded: Jun 6, 2022, 7:19:10 PM
 BASEIMAGE ?= gcr.io/distroless/static-debian11@sha256:d6fa9db9548b5772860fecddb11d84f9ebd7e0321c0cb3c02870402680cc315f
-IPTIMAGE ?= registry.k8s.io/build-image/distroless-iptables:v0.1.2
+IPTIMAGE ?= gcr.io/gke-release/distroless-iptables:v0.1.2-gke.1
 
 # These rules MUST be expanded at reference time (hence '=') as BINARY
 # is dynamically scoped.


### PR DESCRIPTION
This registry claims to fix new vulnerabilities quicker than the upstream.
If it will turn out unsuitable in the future we could always return back to k8s registry.