### PR TITLE
Increase build timeout

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,7 +1,7 @@
 # See https://cloud.google.com/cloud-build/docs/build-config
 
 # this must be specified in seconds. If omitted, defaults to 600s (10 mins)
-timeout: 7200s
+timeout: 10800s
 steps:
   - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20211118-2f2d816b90'
     entrypoint: bash


### PR DESCRIPTION
The build for all images for all supported arch takes ~1h50min and it may not fit the current 2h sometimes.  https://github.com/kubernetes/dns/issues/564#issuecomment-1372030269

One of the options is to investigate if the build parallelisation would decrease the build time, but that's not a priority and may be would be done later.