### PR TITLE
Update DNS specification with RFC1035

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -8,6 +8,8 @@ other protocols and mechanisms, DNS is very commonly used and is a
 highly recommended add-on. The actual DNS service itself need not
 be provided by the default Kube-DNS implementation. This document
 is intended to provide a baseline for commonality between implementations.
+All the implementations must adhere to the corresponding RFCs specifications,
+specifically the [RFC1035 Domain names - Implementation and specification](https://www.rfc-editor.org/rfc/rfc1035)
 
 ## 1 - Schema Version
 


### PR DESCRIPTION
Maybe is redundant, but for compatibility reasons we don't want Kubernetes DNS be different than the other DNS implementations, so all the same rules and limitations apply.

