### PR TITLE
Update distroless-iptables and base-debian11 images

### DIFF
--- a/images/dnsmasq/Makefile
+++ b/images/dnsmasq/Makefile
@@ -28,8 +28,8 @@ OUTPUT_DIR := _output/$(ARCH)
 export DOCKER_CLI_EXPERIMENTAL=enabled
 
 # Multiarch image
-# Uploaded: Sep 19, 2022, 1:53:32 PM
-BASEIMAGE ?= gcr.io/distroless/base-debian11@sha256:c06bf48fa67dab06db6027109d3d802aa5b7d213c86a9eabc4d83f806d18ce1c
+# Uploaded: Feb 10, 2023, 11:04:43 PM
+BASEIMAGE ?= gcr.io/distroless/base-debian11@sha256:5d40383d8cc15830334f30f4a19e2af16923e02ceeca275f0acc39bdf3a1c577
 ifeq ($(ARCH),amd64)
 	COMPILE_IMAGE := k8s.gcr.io/build-image/debian-base-$(ARCH):bullseye-v1.4.1
 else ifeq ($(ARCH),arm)

--- a/images/dnsmasq/validate_dynamic_deps.py
+++ b/images/dnsmasq/validate_dynamic_deps.py
@@ -34,23 +34,31 @@ def relative_to_root(path: pathlib.Path) -> pathlib.Path:
 
 def detect_architecture(cwd: pathlib.Path, target_binary: pathlib.Path) -> str:
     """Read the architecture of the ELF file target_binary using the file command"""
+    print(target_binary)
     result = subprocess.run(['file', target_binary],
                             capture_output=True,
                             text=True,
                             cwd=cwd)
+    print(result.stdout)
     return result.stdout.split(",")[1].strip()
 
 
 def untar_container_image(image_ref: str, output_dir: pathlib.Path):
     """Create a docker container using image_ref use tar to extract the filesystem to output_dir."""
     container_name = replace_img_special_chars(image_ref)
-    subprocess.run(['docker', 'create', '--name', container_name, image_ref],
+    out = subprocess.run(['docker', 'create', '--name', container_name, image_ref],
                    capture_output=True)
-    subprocess.run(f'docker export {container_name} | tar x',
+    print(out.stdout)
+    print(out.stderr)
+    out = subprocess.run(f'docker export {container_name} | tar x',
                    shell=True,
                    cwd=output_dir,
                    capture_output=True)
-    subprocess.run(['docker', 'rm', container_name], capture_output=True)
+    print(out.stdout)
+    print(out.stderr)
+    out = subprocess.run(['docker', 'rm', container_name], capture_output=True)
+    print(out.stdout)
+    print(out.stderr)
 
 
 def detect_dependencies(cwd: pathlib.Path,
@@ -105,6 +113,8 @@ def main(image_ref: str, target_binary: str, clean=True):
     output_dir = pathlib.Path(IMAGE_DIR, container_name)
     target_binary = relative_to_root(pathlib.Path(target_binary))
 
+    print(container_name)
+    print(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
     untar_container_image(image_ref, output_dir)
     target_binary_arch = detect_architecture(output_dir, target_binary)

--- a/images/dnsmasq/validate_dynamic_deps.py
+++ b/images/dnsmasq/validate_dynamic_deps.py
@@ -40,6 +40,7 @@ def detect_architecture(cwd: pathlib.Path, target_binary: pathlib.Path) -> str:
                             cwd=cwd)
     if len(result.stdout.split(",")) <= 1:
         # File not found
+        print("file %s not found" % target_binary)
         return ""
     return result.stdout.split(",")[1].strip()
 
@@ -135,6 +136,9 @@ def main(image_ref: str, target_binary: str, clean=True):
                 dep_path = resolve_container_link(output_dir, dep_path)
 
             dep_arch = detect_architecture(output_dir, dep_path)
+            if dep_arch == "":
+                # Dependency not found
+                continue
 
             if dep_arch != target_binary_arch:
                 wrong_arch[dep_path] = dep_arch

--- a/images/dnsmasq/validate_dynamic_deps.py
+++ b/images/dnsmasq/validate_dynamic_deps.py
@@ -38,7 +38,7 @@ def detect_architecture(cwd: pathlib.Path, target_binary: pathlib.Path) -> str:
                             capture_output=True,
                             text=True,
                             cwd=cwd)
-    if len(result.stdout.split(",")) == 0:
+    if len(result.stdout.split(",")) <= 1:
         # File not found
         return ""
     return result.stdout.split(",")[1].strip()

--- a/images/dnsmasq/validate_dynamic_deps.py
+++ b/images/dnsmasq/validate_dynamic_deps.py
@@ -28,6 +28,7 @@ def replace_img_special_chars(image_ref: str) -> str:
 
 
 def relative_to_root(path: pathlib.Path) -> pathlib.Path:
+    path = pathlib.Path(path)
     return path.relative_to(path.anchor)
 
 

--- a/rules.mk
+++ b/rules.mk
@@ -32,9 +32,7 @@ ALL_ARCH := amd64 arm arm64 ppc64le s390x
 # Multiarch image
 # Uploaded: Jun 6, 2022, 7:19:10 PM
 BASEIMAGE ?= gcr.io/distroless/static-debian11@sha256:d6fa9db9548b5772860fecddb11d84f9ebd7e0321c0cb3c02870402680cc315f
-
-# v0.2.0-gke.2
-IPTIMAGE ?= gcr.io/gke-release/distroless-iptables@sha256:43929c06cad5cd1dcc91da5268160cfb6990f96409bc11f4f66891f0529dbc36
+IPTIMAGE ?= gcr.io/gke-release/distroless-iptables:v0.2.0-gke.2@sha256:43929c06cad5cd1dcc91da5268160cfb6990f96409bc11f4f66891f0529dbc36
 
 # These rules MUST be expanded at reference time (hence '=') as BINARY
 # is dynamically scoped.

--- a/rules.mk
+++ b/rules.mk
@@ -32,7 +32,9 @@ ALL_ARCH := amd64 arm arm64 ppc64le s390x
 # Multiarch image
 # Uploaded: Jun 6, 2022, 7:19:10 PM
 BASEIMAGE ?= gcr.io/distroless/static-debian11@sha256:d6fa9db9548b5772860fecddb11d84f9ebd7e0321c0cb3c02870402680cc315f
-IPTIMAGE ?= gcr.io/gke-release/distroless-iptables:v0.1.2-gke.1
+
+# v0.2.0-gke.2
+IPTIMAGE ?= gcr.io/gke-release/distroless-iptables@sha256:43929c06cad5cd1dcc91da5268160cfb6990f96409bc11f4f66891f0529dbc36
 
 # These rules MUST be expanded at reference time (hence '=') as BINARY
 # is dynamically scoped.


### PR DESCRIPTION
To address vulnerabilities:
1. CVE-2022-2097
2. CVE-2022-4304
3. CVE-2023-0286
4. CVE-2022-4450
5. CVE-2023-0215

Fixes #572 