### PR TITLE
Update distroless-iptables 0.2.0-gke.2 -> 0.2.1-gke.1

### DIFF
--- a/rules.mk
+++ b/rules.mk
@@ -32,7 +32,7 @@ ALL_ARCH := amd64 arm arm64 ppc64le s390x
 # Multiarch image
 # Uploaded: Jun 6, 2022, 7:19:10 PM
 BASEIMAGE ?= gcr.io/distroless/static-debian11@sha256:d6fa9db9548b5772860fecddb11d84f9ebd7e0321c0cb3c02870402680cc315f
-IPTIMAGE ?= gcr.io/gke-release/distroless-iptables:v0.2.0-gke.2@sha256:43929c06cad5cd1dcc91da5268160cfb6990f96409bc11f4f66891f0529dbc36
+IPTIMAGE ?= gcr.io/gke-release/distroless-iptables:v0.2.1-gke.1@sha256:8a531ccf814724529d9f9dace8eeb9a20581a700c2bcd83101840b1b515982ae
 
 # These rules MUST be expanded at reference time (hence '=') as BINARY
 # is dynamically scoped.


### PR DESCRIPTION
distroless-iptables v0.2.0-gke.2 uses go1.19.4, while v0.2.1-gke.1 uses go1.19.6.