### PR TITLE
Update README, add note about k8s version compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,7 @@ Follow these steps to make changes and release a new binary.
 6. Images will be available in the repo registry.k8s.io/dns/. The node-cache image with tag 1.15.14 can be found at registry.k8s.io/dns/k8s-dns-node-cache:1.15.14. Older versions are at registry.k8s.io/k8s-dns-node-cache:<TAG>
 7. Submit a PR for the kubernetes/kubernetes repository to switch to the new
    version of the containers. Example - https://github.com/kubernetes/kubernetes/pull/106189
+   
+## Version compatibility
+
+There is no version compatibility requirements with Kubernetes releases. Version numbers in this repo are not related to Kubernetes versions.


### PR DESCRIPTION
I like others (https://github.com/kubernetes/dns/issues/487) were wondering if there is any incompatibility between the containers in this repo and k8s releases but it's not clear from the main README. So here I'm adding a note to make it clear as looking for version compatibility issues is now a large part of managing the lifecycle of k8s clusters and their components 🙂