### PR TITLE
Don't run kubelet in the E2E test mock cluster

### DIFF
--- a/pkg/e2e/cluster.go
+++ b/pkg/e2e/cluster.go
@@ -53,7 +53,6 @@ func (cl *Cluster) SetUp() {
 
 	cl.StartEtcd()
 	cl.StartApiServer()
-	cl.StartKubelet()
 
 	cl.WaitForApiServer()
 }
@@ -62,7 +61,6 @@ func (cl *Cluster) SetUp() {
 func (cl *Cluster) TearDown() {
 	Log.Logf("Teardown")
 
-	cl.StopKubelet()
 	cl.StopApiServer()
 	cl.StopEtcd()
 }


### PR DESCRIPTION
The existing E2E tests don't need kubelet (proven as this commit still
passing presubmit), while the execution of kubelet started to cause
mysterious failures recently (#605). Let's exclude kubelet in the mock
cluster for now. Not completely removing the relevant code in case some
future tests need them, then #605 can be investigated at that time.
