### PR TITLE
Use tag gcr.io/distroless/base-debian11:latest for dnsmasq base image

### DIFF
--- a/images/dnsmasq/Makefile
+++ b/images/dnsmasq/Makefile
@@ -28,8 +28,7 @@ OUTPUT_DIR := _output/$(ARCH)
 export DOCKER_CLI_EXPERIMENTAL=enabled
 
 # Multiarch image
-# Uploaded: Jun 2, 2023, 12:57:53 PM
-BASEIMAGE ?= gcr.io/distroless/base-debian11@sha256:73deaaf6a207c1a33850257ba74e0f196bc418636cada9943a03d7abea980d6d
+BASEIMAGE ?= gcr.io/distroless/base-debian11:latest
 ifeq ($(ARCH),amd64)
 	COMPILE_IMAGE := registry.k8s.io/build-image/debian-base-$(ARCH):bullseye-v1.4.1
 else ifeq ($(ARCH),arm)


### PR DESCRIPTION
To alleviate the pain of continuous bumping.