### PR TITLE
refactor: upgrade base images version for vuln fixes

### DIFF
--- a/rules.mk
+++ b/rules.mk
@@ -30,9 +30,10 @@ SRC_DIRS := cmd pkg
 
 ALL_ARCH := amd64 arm arm64 ppc64le s390x
 # Multiarch image
-# Uploaded: Jun 2, 2023, 12:51:04 PM
-BASEIMAGE ?= gcr.io/distroless/static-debian11@sha256:7198a357ff3a8ef750b041324873960cf2153c11cc50abb9d8d5f8bb089f6b4e
-IPTIMAGE ?= registry.k8s.io/build-image/distroless-iptables:v0.5.2@sha256:8e51d18dbf2003391b30a079458a9513774df7f7feb748710bc1d551f3b7da94
+# Multiarch image
+# Uploaded: May 8, 2024, 13:42:56 PM
+BASEIMAGE ?= gcr.io/distroless/static-debian12@sha256:41972110a1c1a5c0b6adb283e8aa092c43c31f7c5d79b8656fbffff2c3e61f05
+IPTIMAGE ?= registry.k8s.io/build-image/distroless-iptables:v0.5.4@sha256:296d0fd9f533e2ae31c489c14fb0b6321b7074983764141c9aa940fc4b4d3c01
 
 # These rules MUST be expanded at reference time (hence '=') as BINARY
 # is dynamically scoped.


### PR DESCRIPTION
Upgrading base images as discussed in #620.
In this change, the base image is upgraded to `Debian 12` and the IPT image to `v0.5.3`, the latest release of distroless-iptables.

<details>

<summary>Available distroless-iptables tags</summary>

```bash
skopeo list-tags docker://registry.k8s.io/build-image/distroless-iptables
{
    "Repository": "registry.k8s.io/build-image/distroless-iptables",
    "Tags": [
        "sha256-0083d9e4ebc9581f604f6bb68dd97c115293c7fba38fa5d249309fb99da33652.sig",
        "sha256-13ac9b3c476d7290a4451d65d09d6016a2cb89836ffbfa4eae55b72731a22080.sig",
        "sha256-146e96c6b3349b46fcbcdd354be4b8db7a28915be9b0b46c01537ced8912989a.sig",
        "sha256-17282b8c158e7efe33a6ff21eae36a9b6a39c49db2b2376af2c5917b1ca4efdf.sig",
        "sha256-33ea7b61b3dda4323872a7a726e4753ec6848c38faadb6776af950f4fc0c4507.sig",
        "sha256-38e6b091d238094f081efad3e2b362e6480b2156f5f4fba6ea46835ecdcd47e2.sig",
        "sha256-49ffe914c7080b3a001524dcee70e7155ae540452a1b5083048368e47a67c776.sig",
        "sha256-6503d326a7df8eb4dfe40583463bac7635f2e7fede8b79a084b91b0005aea798.sig",
        "sha256-67279645e61c700b2ae96ebc2a8397b230cb922169307078935a7d0864e0202a.sig",
        "sha256-691c591a093063b119abc4753ab792b61271c66f2dbbc7d5219f914197274cc2.sig",
        "sha256-6b7fef6529c4f47e40b38eb07f3de832f1c8a808ed0a895408053d00c34b6c86.sig",
        "sha256-6e4fe3a1070553235130a64a15ca4916b953882e13652d52b1f54dab862ab3fa.sig",
        "sha256-7ee5c2ea5b0bacb43a2acee7e4a38816d8de193488abe486a252bdf19e03967d.sig",
        "sha256-81e1435cb9abc2f0a6e869d0af58ac1474321cd099682077bf4dd0906913a2c5.sig",
        "sha256-87dfc9bbab2ce1f8bb4af34dff3158f782eed94125a9da77ed04a9b95f7528cb.sig",
        "sha256-8da974a31e3703bba249b5d065f8899a9dca7ffc85ec1ac2f36fd002d745ce68.sig",
        "sha256-8e51d18dbf2003391b30a079458a9513774df7f7feb748710bc1d551f3b7da94.sig",
        "sha256-965b0a9227c039c393d44de97450a698ada6952a74b9ff12c315f91dc2bdd45c.sig",
        "sha256-985ad3611a88a90432b871ee1d986701d8185b6403ed468d09d5e9b7e465faa5.sig",
        "sha256-98f67b5738f7b851d40f4288c489fa3df3244e1b878944cc52aff4dfcba9c947.sig",
        "sha256-be9eacde4196a202e95702da31f2ea0f82a33ef9d569fa5c02242c497418f27e.sig",
        "sha256-c0ddb4794bc8a3631e3373015f913c00b230ee54f87bde9ade195b3a3415c60f.sig",
        "sha256-c7b5f6ec1a3eab247ab839c804a791917f5567e8f7e401e65de52248e78080b7.sig",
        "sha256-cdc68f6ef3caf8eeddde4a99090fc2c2936cd18b34dc649edb6d513086225c7a.sig",
        "sha256-d03d555824df3b8898c86cb86bc83c3cb254484cd0b6ed61c133f9cf38accb2d.sig",
        "sha256-d6abe4fa761c01c13fbe3b1d2e5417de56718bef270421b4e947c5814c52ce5c.sig",
        "sha256-dae9eb247981a394f49d3f5c840bf5a6644b15077ecd3ab9585c1aa5b77e76a0.sig",
        "sha256-e20be6e9f506f1c5e4148271eef088311b9bfb25ec8ecd635508de70ff36bc63.sig",
        "sha256-f6e2342cfaa371ef0e512561cf9505f5f926f34f1a9f05584889bcff615d5404.sig",
        "sha256-fc259355994e6c6c1025a7cd2d1bdbf201708e9e11ef1dfd3ef787a7ce45730d.sig",
        "v0.1.0",
        "v0.1.1",
        "v0.1.2",
        "v0.2.0",
        "v0.2.1",
        "v0.2.10",
        "v0.2.2",
        "v0.2.3",
        "v0.2.4",
        "v0.2.5",
        "v0.2.6",
        "v0.2.7",
        "v0.2.8",
        "v0.2.9",
        "v0.3.0",
        "v0.3.1",
        "v0.3.2",
        "v0.3.3",
        "v0.4.0",
        "v0.4.1",
        "v0.4.2",
        "v0.4.3",
        "v0.4.4",
        "v0.4.5",
        "v0.4.6",
        "v0.4.7",
        "v0.5.0",
        "v0.5.1",
        "v0.5.2",
        "v0.5.3"
    ]
}
```

</details>

<details>

<summary>trivy scan of distroless-iptables v0.5.3</summary>

```bash
trivy image registry.k8s.io/build-image/distroless-iptables:v0.5.3
2024-05-08T14:09:39+02:00	INFO	Vulnerability scanning is enabled
2024-05-08T14:09:39+02:00	INFO	Secret scanning is enabled
2024-05-08T14:09:39+02:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-05-08T14:09:39+02:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.51/docs/scanner/secret/#recommendation for faster secret detection
2024-05-08T14:09:39+02:00	INFO	Detected OS	family="debian" version="12.5"
2024-05-08T14:09:39+02:00	INFO	[debian] Detecting vulnerabilities...	os_version="12" pkg_num=29
2024-05-08T14:09:39+02:00	INFO	Number of language-specific files	num=1
2024-05-08T14:09:39+02:00	INFO	[gobinary] Detecting vulnerabilities...

registry.k8s.io/build-image/distroless-iptables:v0.5.3 (debian 12.5)

Total: 26 (UNKNOWN: 0, LOW: 17, MEDIUM: 7, HIGH: 2, CRITICAL: 0)

┌──────────────┬──────────────────┬──────────┬──────────────┬───────────────────┬────────────────┬──────────────────────────────────────────────────────────────┐
│   Library    │  Vulnerability   │ Severity │    Status    │ Installed Version │ Fixed Version  │                            Title                             │
├──────────────┼──────────────────┼──────────┼──────────────┼───────────────────┼────────────────┼──────────────────────────────────────────────────────────────┤
│ coreutils    │ CVE-2016-2781    │ LOW      │ will_not_fix │ 9.1-1             │                │ coreutils: Non-privileged session can escape to the parent   │
│              │                  │          │              │                   │                │ session in chroot                                            │
│              │                  │          │              │                   │                │ https://avd.aquasec.com/nvd/cve-2016-2781                    │
│              ├──────────────────┤          ├──────────────┤                   ├────────────────┼──────────────────────────────────────────────────────────────┤
│              │ CVE-2017-18018   │          │ affected     │                   │                │ coreutils: race condition vulnerability in chown and chgrp   │
│              │                  │          │              │                   │                │ https://avd.aquasec.com/nvd/cve-2017-18018                   │
├──────────────┼──────────────────┤          │              ├───────────────────┼────────────────┼──────────────────────────────────────────────────────────────┤
│ iptables     │ CVE-2012-2663    │          │              │ 1.8.9-2           │                │ iptables: --syn flag bypass                                  │
│              │                  │          │              │                   │                │ https://avd.aquasec.com/nvd/cve-2012-2663                    │
├──────────────┼──────────────────┼──────────┼──────────────┼───────────────────┼────────────────┼──────────────────────────────────────────────────────────────┤
│ libc6        │ CVE-2024-2961    │ HIGH     │ fixed        │ 2.36-9+deb12u4    │ 2.36-9+deb12u6 │ glibc: Out of bounds write in iconv may lead to remote       │
│              │                  │          │              │                   │                │ code...                                                      │
│              │                  │          │              │                   │                │ https://avd.aquasec.com/nvd/cve-2024-2961                    │
│              ├──────────────────┤          │              │                   ├────────────────┼──────────────────────────────────────────────────────────────┤
│              │ CVE-2024-33599   │          │              │                   │ 2.36-9+deb12u7 │ glibc: stack-based buffer overflow in netgroup cache         │
│              │                  │          │              │                   │                │ https://avd.aquasec.com/nvd/cve-2024-33599                   │
│              ├──────────────────┼──────────┤              │                   │                ├──────────────────────────────────────────────────────────────┤
│              │ CVE-2024-33600   │ MEDIUM   │              │                   │                │ glibc: null pointer dereferences after failed netgroup cache │
│              │                  │          │              │                   │                │ insertion                                                    │
│              │                  │          │              │                   │                │ https://avd.aquasec.com/nvd/cve-2024-33600                   │
│              ├──────────────────┤          │              │                   │                ├──────────────────────────────────────────────────────────────┤
│              │ CVE-2024-33601   │          │              │                   │                │ glibc: netgroup cache may terminate daemon on memory         │
│              │                  │          │              │                   │                │ allocation failure                                           │
│              │                  │          │              │                   │                │ https://avd.aquasec.com/nvd/cve-2024-33601                   │
│              ├──────────────────┤          │              │                   │                ├──────────────────────────────────────────────────────────────┤
│              │ CVE-2024-33602   │          │              │                   │                │ glibc: netgroup cache assumes NSS callback uses in-buffer    │
│              │                  │          │              │                   │                │ strings                                                      │
│              │                  │          │              │                   │                │ https://avd.aquasec.com/nvd/cve-2024-33602                   │
│              ├──────────────────┼──────────┼──────────────┤                   ├────────────────┼──────────────────────────────────────────────────────────────┤
│              │ CVE-2010-4756    │ LOW      │ affected     │                   │                │ glibc: glob implementation can cause excessive CPU and       │
│              │                  │          │              │                   │                │ memory consumption due to...                                 │
│              │                  │          │              │                   │                │ https://avd.aquasec.com/nvd/cve-2010-4756                    │
│              ├──────────────────┤          │              │                   ├────────────────┼──────────────────────────────────────────────────────────────┤
│              │ CVE-2018-20796   │          │              │                   │                │ glibc: uncontrolled recursion in function                    │
│              │                  │          │              │                   │                │ check_dst_limits_calc_pos_1 in posix/regexec.c               │
│              │                  │          │              │                   │                │ https://avd.aquasec.com/nvd/cve-2018-20796                   │
│              ├──────────────────┤          │              │                   ├────────────────┼──────────────────────────────────────────────────────────────┤
│              │ CVE-2019-1010022 │          │              │                   │                │ glibc: stack guard protection bypass                         │
│              │                  │          │              │                   │                │ https://avd.aquasec.com/nvd/cve-2019-1010022                 │
│              ├──────────────────┤          │              │                   ├────────────────┼──────────────────────────────────────────────────────────────┤
│              │ CVE-2019-1010023 │          │              │                   │                │ glibc: running ldd on malicious ELF leads to code execution  │
│              │                  │          │              │                   │                │ because of...                                                │
│              │                  │          │              │                   │                │ https://avd.aquasec.com/nvd/cve-2019-1010023                 │
│              ├──────────────────┤          │              │                   ├────────────────┼──────────────────────────────────────────────────────────────┤
│              │ CVE-2019-1010024 │          │              │                   │                │ glibc: ASLR bypass using cache of thread stack and heap      │
│              │                  │          │              │                   │                │ https://avd.aquasec.com/nvd/cve-2019-1010024                 │
│              ├──────────────────┤          │              │                   ├────────────────┼──────────────────────────────────────────────────────────────┤
│              │ CVE-2019-1010025 │          │              │                   │                │ glibc: information disclosure of heap addresses of           │
│              │                  │          │              │                   │                │ pthread_created thread                                       │
│              │                  │          │              │                   │                │ https://avd.aquasec.com/nvd/cve-2019-1010025                 │
│              ├──────────────────┤          │              │                   ├────────────────┼──────────────────────────────────────────────────────────────┤
│              │ CVE-2019-9192    │          │              │                   │                │ glibc: uncontrolled recursion in function                    │
│              │                  │          │              │                   │                │ check_dst_limits_calc_pos_1 in posix/regexec.c               │
│              │                  │          │              │                   │                │ https://avd.aquasec.com/nvd/cve-2019-9192                    │
├──────────────┼──────────────────┤          │              ├───────────────────┼────────────────┼──────────────────────────────────────────────────────────────┤
│ libip4tc2    │ CVE-2012-2663    │          │              │ 1.8.9-2           │                │ iptables: --syn flag bypass                                  │
│              │                  │          │              │                   │                │ https://avd.aquasec.com/nvd/cve-2012-2663                    │
├──────────────┤                  │          │              │                   ├────────────────┤                                                              │
│ libip6tc2    │                  │          │              │                   │                │                                                              │
│              │                  │          │              │                   │                │                                                              │
├──────────────┼──────────────────┤          │              ├───────────────────┼────────────────┼──────────────────────────────────────────────────────────────┤
│ libjansson4  │ CVE-2020-36325   │          │              │ 2.14-2            │                │ jansson: out-of-bounds read in json_loads() due to a parsing │
│              │                  │          │              │                   │                │ error                                                        │
│              │                  │          │              │                   │                │ https://avd.aquasec.com/nvd/cve-2020-36325                   │
├──────────────┼──────────────────┼──────────┤              ├───────────────────┼────────────────┼──────────────────────────────────────────────────────────────┤
│ libssl3      │ CVE-2023-5678    │ MEDIUM   │              │ 3.0.11-1~deb12u2  │                │ openssl: Generating excessively long X9.42 DH keys or        │
│              │                  │          │              │                   │                │ checking excessively long X9.42...                           │
│              │                  │          │              │                   │                │ https://avd.aquasec.com/nvd/cve-2023-5678                    │
│              ├──────────────────┤          │              │                   ├────────────────┼──────────────────────────────────────────────────────────────┤
│              │ CVE-2023-6129    │          │              │                   │                │ mysql: openssl: POLY1305 MAC implementation corrupts vector  │
│              │                  │          │              │                   │                │ registers on PowerPC                                         │
│              │                  │          │              │                   │                │ https://avd.aquasec.com/nvd/cve-2023-6129                    │
│              ├──────────────────┤          │              │                   ├────────────────┼──────────────────────────────────────────────────────────────┤
│              │ CVE-2023-6237    │          │              │                   │                │ openssl: Excessive time spent checking invalid RSA public    │
│              │                  │          │              │                   │                │ keys                                                         │
│              │                  │          │              │                   │                │ https://avd.aquasec.com/nvd/cve-2023-6237                    │
│              ├──────────────────┤          │              │                   ├────────────────┼──────────────────────────────────────────────────────────────┤
│              │ CVE-2024-0727    │          │              │                   │                │ openssl: denial of service via null dereference              │
│              │                  │          │              │                   │                │ https://avd.aquasec.com/nvd/cve-2024-0727                    │
│              ├──────────────────┼──────────┤              │                   ├────────────────┼──────────────────────────────────────────────────────────────┤
│              │ CVE-2007-6755    │ LOW      │              │                   │                │ Dual_EC_DRBG: weak pseudo random number generator            │
│              │                  │          │              │                   │                │ https://avd.aquasec.com/nvd/cve-2007-6755                    │
│              ├──────────────────┤          │              │                   ├────────────────┼──────────────────────────────────────────────────────────────┤
│              │ CVE-2010-0928    │          │              │                   │                │ openssl: RSA authentication weakness                         │
│              │                  │          │              │                   │                │ https://avd.aquasec.com/nvd/cve-2010-0928                    │
│              ├──────────────────┤          ├──────────────┤                   ├────────────────┼──────────────────────────────────────────────────────────────┤
│              │ CVE-2024-2511    │          │ fix_deferred │                   │                │ openssl: Unbounded memory growth with session handling in    │
│              │                  │          │              │                   │                │ TLSv1.3                                                      │
│              │                  │          │              │                   │                │ https://avd.aquasec.com/nvd/cve-2024-2511                    │
├──────────────┼──────────────────┤          ├──────────────┼───────────────────┼────────────────┼──────────────────────────────────────────────────────────────┤
│ libxtables12 │ CVE-2012-2663    │          │ affected     │ 1.8.9-2           │                │ iptables: --syn flag bypass                                  │
│              │                  │          │              │                   │                │ https://avd.aquasec.com/nvd/cve-2012-2663                    │
└──────────────┴──────────────────┴──────────┴──────────────┴───────────────────┴────────────────┴──────────────────────────────────────────────────────────────┘

go-runner (gobinary)

Total: 1 (UNKNOWN: 1, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬─────────────────┬────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │  Fixed Version  │                   Title                    │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼─────────────────┼────────────────────────────────────────────┤
│ stdlib  │ CVE-2024-24788 │ UNKNOWN  │ fixed  │ 1.22.2            │ 1.21.10, 1.22.3 │ https://avd.aquasec.com/nvd/cve-2024-24788 │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴─────────────────┴────────────────────────────────────────────┘

```

</details>
