### PR TITLE
Update go version to 1.22

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ REGISTRY ?= gcr.io/k8s-staging-dns
 # Default architecture to build for.
 ARCH ?= amd64
 # Image to use for building.
-BUILD_IMAGE ?= golang:1.21-bookworm
+BUILD_IMAGE ?= golang:1.22.3-bookworm
 # Containers will be named: $(CONTAINER_PREFIX)-$(BINARY)-$(ARCH):$(VERSION)
 CONTAINER_PREFIX ?= k8s-dns
 # Caching for go builds, disabled for CI

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/dns
 
-go 1.20
+go 1.22
 
 require (
 	github.com/coredns/caddy v1.1.1


### PR DESCRIPTION
go lang version 1.22 is required by k8s.io/kubernetes in vendor/modules.txt. 