### PR TITLE
Send SIGUSR1 to dnsmasq periodically

### DIFF
--- a/cmd/dnsmasq-nanny/main.go
+++ b/cmd/dnsmasq-nanny/main.go
@@ -37,6 +37,7 @@ var (
 		RunNannyOpts: dnsmasq.RunNannyOpts{
 			DnsmasqExec:     "/usr/sbin/dnsmasq",
 			RestartOnChange: false,
+			LogInterval:     time.Duration(0),
 		},
 		configDir:     "/etc/k8s/dns/dnsmasq-nanny",
 		syncInterval:  10 * time.Second,
@@ -69,6 +70,9 @@ Any arguments given after "--" will be passed directly to dnsmasq itself.
 		"interval to check for configuration updates")
 	flag.StringVar(&opts.kubednsServer, "kubednsServer", opts.kubednsServer,
 		"local kubedns instance address for non-IP name resolution")
+	flag.DurationVar(&opts.LogInterval, "logInterval",
+		opts.LogInterval,
+		"interval to send SIGUSR1 to dnsmasq which triggers statistics logging (if zero, SIGUSR1 is not sent)")
 	klog.InitFlags(nil)
 	flag.Parse()
 }

--- a/test/fixtures/mock-dnsmasq.sh
+++ b/test/fixtures/mock-dnsmasq.sh
@@ -37,6 +37,21 @@ sleepThenError() {
 	exit 1
 }
 
+COUNT=0
+exitOnSecondCall() {
+	: $((COUNT+=1))
+	echo "Function call no ${COUNT}"
+	if [ $COUNT -ge 2 ]; then
+		exit 0
+	fi
+}
+
+trapTwice() {
+	trap exitOnSecondCall USR1
+	echo "Trap registered"
+	runForever
+}
+
 ARGS="$*"
 RUN=
 
@@ -50,6 +65,7 @@ while [ ! -z "$1" ]; do
 		--exitWithSuccess) RUN=exitWithSuccess;;
 		--runForever)      RUN=runForever;;
 		--sleepThenError)  RUN=sleepThenError;;
+		--trapTwice)       RUN=trapTwice;;
 	esac
 	shift
 done


### PR DESCRIPTION
This adds a feature flag `--logInterval` for periodic triggering dnsmasq to log its statistics by sending `SIGUSR1` to it.

The new motivation for adding this feature comes from dnsmasq changes in `v2.90`: the new [flag](https://thekelleys.org.uk/gitweb/?p=dnsmasq.git;a=commit;h=416390f9962e455769aa8ab6df0e105cae07ae55) `--max-tcp-connections`and the related [statistics](https://thekelleys.org.uk/gitweb/?p=dnsmasq.git;a=commit;h=69877f565a969260cf2761b2fd512d6c28dbf2f0) of TCP connection utilisation added to the log output triggered by `SIGUSR1`.

The change was benchmarked (see the commit description) and no negative impact was observed.