### PR TITLE
Update e2e test images, fix test timeouts

### DIFF
--- a/pkg/e2e/cluster.go
+++ b/pkg/e2e/cluster.go
@@ -129,10 +129,10 @@ func (cl *Cluster) StartApiServer() {
 		"--net=host",
 		"--pid=host",
 		cl.HyperkubeImage,
-		"/hyperkube", "apiserver",
+		"kube-apiserver",
 		"--insecure-bind-address=0.0.0.0",
 		"--service-cluster-ip-range=10.0.0.1/24",
-		"--etcd_servers=http://127.0.0.1:2379",
+		"--etcd-servers=http://127.0.0.1:2379",
 		"--v=2")
 }
 

--- a/pkg/e2e/dns/dns.go
+++ b/pkg/e2e/dns/dns.go
@@ -45,7 +45,6 @@ func (kd *KubeDNS) Start(name string, args ...string) {
 
 	args = append(
 		args,
-		"--logtostderr",
 		"--dns-port", "10053",
 		"--kubecfg-file", fr.Path("test/e2e/cluster/config"))
 

--- a/pkg/e2e/options.go
+++ b/pkg/e2e/options.go
@@ -17,9 +17,11 @@ limitations under the License.
 package e2e
 
 const (
-	etcdImage      = "quay.io/coreos/etcd:v3.0.14"
-	hyperkubeImage = "registry.k8s.io/hyperkube:v1.5.1"
-	dnsmasqImage   = "registry.k8s.io/k8s-dns-dnsmasq-amd64:1.14.5"
+	etcdImage = "quay.io/coreos/etcd:v3.5.16"
+	// TODO remove hyperkube, it is deprecated
+	hyperkubeImage = "registry.k8s.io/hyperkube:v1.18.20"
+	// TODO Fix kubedns e2e test that uses this image, stops working after 1.14.10
+	dnsmasqImage = "registry.k8s.io/k8s-dns-dnsmasq-amd64:1.14.10"
 )
 
 type Options struct {

--- a/test/e2e/cluster/manifests/addon-manager.json
+++ b/test/e2e/cluster/manifests/addon-manager.json
@@ -11,7 +11,7 @@
 		"containers": [
 			{
 				"name": "kube-addon-manager",
-				"image": "registry.k8s.io/kube-addon-manager-amd64:v6.1",
+				"image": "registry.k8s.io/kube-addon-manager-amd64:v9.1.1",
 				"resources": {
 					"requests": {
 						"cpu": "5m",

--- a/test/e2e/cluster/manifests/master.json
+++ b/test/e2e/cluster/manifests/master.json
@@ -10,7 +10,7 @@
     "containers": [
       {
         "name": "controller-manager",
-        "image": "registry.k8s.io/hyperkube-amd64:v1.5.1",
+        "image": "registry.k8s.io/hyperkube-amd64:v1.18.20",
         "command": [
           "/hyperkube",
           "controller-manager",
@@ -30,7 +30,7 @@
       },
       {
         "name": "scheduler",
-        "image": "registry.k8s.io/hyperkube-amd64:v1.5.1",
+        "image": "registry.k8s.io/hyperkube-amd64:v1.18.20",
         "command": [
           "/hyperkube",
           "scheduler",
@@ -41,7 +41,7 @@
       },
       {
         "name": "setup",
-        "image": "registry.k8s.io/hyperkube-amd64:v1.5.1",
+        "image": "registry.k8s.io/hyperkube-amd64:v1.18.20",
         "command": [
           "/setup-files.sh",
           "IP:10.0.0.1,DNS:kubernetes,DNS:kubernetes.default,DNS:kubernetes.default.svc,DNS:kubernetes.default.svc.cluster.local"

--- a/test/e2e/kubedns/kubedns.go
+++ b/test/e2e/kubedns/kubedns.go
@@ -51,7 +51,7 @@ var _ = Describe("kube-dns", func() {
 				}
 
 				return fmt.Errorf("expected %v, but got %v", expected, names)
-			}).Should(om.Succeed())
+			}, "5s", "1s").Should(om.Succeed())
 		})
 
 		It("should stop", func() {

--- a/test/e2e/sidecar/Dockerfile.e2e
+++ b/test/e2e/sidecar/Dockerfile.e2e
@@ -13,11 +13,11 @@
 # limitations under the License.
 #
 # Builds the docker container for the e2e test.
-FROM registry.k8s.io/kube-dnsmasq-amd64:1.4
+FROM alpine:3.20
 MAINTAINER Bowei Du <bowei@google.com>
 
 COPY bin/amd64/sidecar /sidecar
 COPY bin/amd64/sidecar-e2e /sidecar-e2e
-RUN apk update && apk add curl bind-tools
+RUN apk update && apk add curl bind-tools dnsmasq
 
 ENTRYPOINT ["/sidecar-e2e", "-mode", "test"]


### PR DESCRIPTION
## Changes
- Update the out of date images used for E2E testing. 
- Remove incorrectly named and deprecated flags

## Linked Issues
https://github.com/kubernetes/dns/issues/646
