### PR TITLE
chore: update base iptable image to remediate vulns

### DIFF
--- a/rules.mk
+++ b/rules.mk
@@ -32,7 +32,7 @@ ALL_ARCH := amd64 arm arm64 ppc64le s390x
 # Multiarch image
 # Uploaded: Nov 12, 2024, 4:36:26 PM
 BASEIMAGE ?= gcr.io/distroless/static-debian12@sha256:f4a57e8ffd7ba407bdd0eb315bb54ef1f21a2100a7f032e9102e4da34fe7c196
-IPTIMAGE ?= registry.k8s.io/build-image/distroless-iptables:v0.5.4@sha256:296d0fd9f533e2ae31c489c14fb0b6321b7074983764141c9aa940fc4b4d3c01
+IPTIMAGE ?= registry.k8s.io/build-image/distroless-iptables:v0.6.5@sha256:3fdb391f7e76cc2301dea2bbb7973b80a89c400dbd967ece59880d03b2b62e65
 
 # These rules MUST be expanded at reference time (hence '=') as BINARY
 # is dynamically scoped.


### PR DESCRIPTION
Bumps version of the iptables image to remediate vulns.

Fixes:
- CVE-2023-5678
- CVE-2023-6129
- CVE-2023-6237
- CVE-2024-0727
- CVE-2024-4603
- CVE-2024-4741
- CVE-2024-5535
- CVE-2024-6119
- CVE-2024-2511
- CVE-2024-9143