### PR TITLE
Bump base images

### DIFF
--- a/images/dnsmasq/Makefile
+++ b/images/dnsmasq/Makefile
@@ -28,10 +28,10 @@ OUTPUT_DIR := _output/$(ARCH)
 export DOCKER_CLI_EXPERIMENTAL=enabled
 
 # Multiarch image
-# Uploaded: Nov 12, 2024, 4:43:54 PM
-BASEIMAGE ?= gcr.io/distroless/base-debian12@sha256:7a4bffcb07307d97aa731b50cb6ab22a68a8314426f4e4428335939b5b1943a5
+# Uploaded: Mar 28, 2025
+BASEIMAGE ?= gcr.io/distroless/base-debian12@sha256:27769871031f67460f1545a52dfacead6d18a9f197db77110cfc649ca2a91f44
 ifeq ($(ARCH),amd64)
-	COMPILE_IMAGE := registry.k8s.io/build-image/debian-base-$(ARCH):bullseye-v1.4.1
+	COMPILE_IMAGE := registry.k8s.io/build-image/debian-base-$(ARCH):bookworm-v1.0.4
 else ifeq ($(ARCH),arm)
 	TRIPLE    ?= arm-linux-gnueabihf
 	QEMUARCH  := arm

--- a/rules.mk
+++ b/rules.mk
@@ -32,7 +32,7 @@ ALL_ARCH := amd64 arm arm64 ppc64le s390x
 # Multiarch image
 # Debian distroless image uploaded on 2025-03-28
 BASEIMAGE ?= gcr.io/distroless/static-debian12@sha256:765ef30aff979959710073e7ba3b163d479a285d7d96d0020fca8c1501de48cb
-IPTIMAGE ?= registry.k8s.io/build-image/distroless-iptables:v0.6.5@sha256:3fdb391f7e76cc2301dea2bbb7973b80a89c400dbd967ece59880d03b2b62e65
+IPTIMAGE ?= registry.k8s.io/build-image/distroless-iptables:v0.6.9@sha256:84bf6f3e75df53f0e7baf30b85ac6e4a5ad456aa7cf776609134b5917eb4837d
 
 # These rules MUST be expanded at reference time (hence '=') as BINARY
 # is dynamically scoped.


### PR DESCRIPTION
followup to #685

distroless-iptables contains the fix for CVE-2025-0395 in node-cache image

base-debian12 contains the fix for CVE-2025-0395 in dnsmasq-nanny image

At this point I'm afraid to ask what's the difference between base-debian and debian-base, but it seems like bumping the amd64 COMPILE_IMAGE is also the right thing to do