### PR TITLE
Add option for node-cache to reload in-process CoreDNS via a signal.

### DIFF
--- a/cmd/node-cache/app/configmap.go
+++ b/cmd/node-cache/app/configmap.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"path"
 	"strings"
+	"syscall"
 	"text/template"
 	"time"
 
@@ -132,6 +133,14 @@ func (c *CacheApp) updateCorefile(dnsConfig *config.Config) {
 	}
 	clog.Infof("Updated Corefile with %d custom stubdomains and upstream servers %s", len(dnsConfig.StubDomains), upstreamServers)
 	clog.Infof("Using config file:\n%s", newConfig.String())
+
+	// Trigger reload of in-process CoreDNS
+	if c.selfProcess != nil {
+		clog.Infof("Sending reload signal to PID %v", c.selfProcess.Pid)
+		if err := c.selfProcess.Signal(syscall.SIGUSR1); err != nil {
+			clog.Errorf("Failed to trigger CoreDNS reload: %v", err)
+		}
+	}
 }
 
 // syncInfo contains all parameters needed to watch a configmap directory for updates

--- a/cmd/node-cache/main.go
+++ b/cmd/node-cache/main.go
@@ -90,6 +90,7 @@ func parseAndValidateFlags() (*app.ConfigParams, error) {
 	flag.StringVar(&params.UpstreamSvcName, "upstreamsvc", "kube-dns", "Service name whose cluster IP is upstream for node-cache")
 	flag.StringVar(&params.HealthPort, "health-port", "8080", "port used by health plugin")
 	flag.BoolVar(&params.SkipTeardown, "skipteardown", false, "indicates whether iptables rules should be torn down on exit")
+	flag.BoolVar(&params.ReloadWithSignal, "reloadwithsignal", false, "use SIGUSR1 on self to reload CoreDNS")
 	flag.Parse()
 
 	for _, ipstr := range strings.Split(params.LocalIPStr, ",") {


### PR DESCRIPTION
When the nodelocaldns addon is applied during a cluster upgrade, there is a risk of deadlock. Consider the following run:

1. node-local-dns ConfigMap is updated.
2. node-cache binary receives the update, writes a new Corefile.
3. CoreDNS's reload plugin picks up the new Corefile and begins to set up a new server instance.
4. node-local-dns DaemonSet is updated.
5. node-local-dns Pod receives SIGTERM with 30s grace period. It begins executing shutdown callbacks, locking instancesMu. One of the callbacks is sending to reload plugin's unbuffered `exit` channel to make its goroutine exit.
6. reload plugin finishes setting up a new server instance, and tries to Stop() the original instance. This requires the instancesMu mutex. instancesMu is locked and to unlock it, reload plugin would have to return to its main loop.
7. Grace period is exceeded and Pod is terminated without tearing down iptables rules.

This seems like a plausible root cause of https://github.com/kubernetes/dns/issues/453.

Reload plugin is still supported after this change. The addon continues to work as-is, but it provides a flag-gated way to reload via SIGUSR1.

In order to enable this new behavior, remove `reload` directives from the Corefile template and add `-reloadwithsignal` to container args.

Reload with SIGUSR1 doesn't cause the deadlock, because signal processing in coredns/caddy is sequential. If SIGTERM comes during SIGUSR1 processing, it will just wait (and hopefully reload and termination will fit in 30 seconds). IF SIGUSR1 comes during SIGTERM processing, well, that's too late for it.