### PR TITLE
fix: reorder cleanup sequence in node-cache teardown

### DIFF
--- a/cmd/node-cache/app/cache_app.go
+++ b/cmd/node-cache/app/cache_app.go
@@ -176,9 +176,6 @@ func (c *CacheApp) TeardownNetworking() error {
 		c.exitChan <- struct{}{}
 	}
 	var err error
-	if c.params.SetupInterface {
-		err = c.netifHandle.RemoveDummyDevice(c.params.InterfaceName)
-	}
 	if c.params.SetupIptables {
 		for _, rule := range c.iptablesRules {
 			exists := true
@@ -198,6 +195,9 @@ func (c *CacheApp) TeardownNetworking() error {
 			// Delete the rule one last time since EnsureRule creates the rule if it doesn't exist
 			err = c.iptables.DeleteRule(rule.table, rule.chain, rule.args...)
 		}
+	}
+	if c.params.SetupInterface {
+		err = c.netifHandle.RemoveDummyDevice(c.params.InterfaceName)
 	}
 	return err
 }


### PR DESCRIPTION
The previous implementation removed the dummy interface before cleaning up iptables rules, which could leave orphaned iptables rules referencing the removed interface. This fix ensures proper cleanup order by:

1. First removing all iptables rules
2. Then removing the dummy interface

This change prevents potential issues where iptables rules might reference a non-existent interface after teardown.

I found this in my testing and confirmed that it was indeed causing errors.
When deleting or updating, the dummy interface is deleted first, causing a disconnect and DNS queries to fail.
I changed the order of the teardown logic and it worked without errors.
This change prevents disconnects from causing errors when updating.
