### PR TITLE
Enhance dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,18 +1,30 @@
 version: 2
 updates:
-- package-ecosystem: docker
-  directory: /images/dnsmasq
-  schedule:
-    interval: weekly
-- package-ecosystem: docker
-  directory: /
-  schedule:
-    interval: weekly
-- package-ecosystem: gomod
-  directory: /
-  schedule:
-    interval: weekly
-  groups:
-    gomod-dependencies:
-      patterns:
-      - '*'
+  - package-ecosystem: "docker"
+    directory: "/images/dnsmasq"
+    schedule:
+      interval: "weekly"
+    labels:
+      - docker
+      - dependencies
+      - ok-to-test
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - docker
+      - dependencies
+      - ok-to-test
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      k8s.io: # Group k8s.io golang dependencies updates
+        patterns:
+          - "k8s.io/*"
+    labels:
+      - go
+      - dependencies
+      - ok-to-test


### PR DESCRIPTION
https://github.com/kubernetes/dns/issues/691 
While Dependabot doesn't parse image versions directly from Makefiles (e.g., `BUILD_IMAGE`), requiring manual updates for those, its automated PRs are crucial. They notify maintainers of new Go or Dockerfile versions, accelerating the update process and reducing manual effort. Dependabot's groupe updates further improve dependency management efficiency, even if some Makefile-defined versions still need manual attention.

Tags are used to improve classification of created PRs.