### PR TITLE
Configure dependabot with two groups: k8s and non-k8s, where k8s only bumps patch version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,9 +21,37 @@ updates:
     schedule:
       interval: "weekly"
     groups:
-      k8s.io: # Group k8s.io golang dependencies updates
+      k8s.io: # Group k8s.io updates.
+        update-types:
+          - patch # We want to keep the latest supported k8s minor and only bump patch version automatically.
+        patterns: # Not all k8s.io dependencies are numbered in parallel with k8s releases, below we list those that do.
+          - "k8s.io/apiextensions-apiserver"
+          - "k8s.io/apimachinery"
+          - "k8s.io/apiserver"
+          - "k8s.io/cli-runtime"
+          - "k8s.io/client-go"
+          - "k8s.io/cloud-provider"
+          - "k8s.io/cluster-bootstrap"
+          - "k8s.io/code-generator"
+          - "k8s.io/component-base"
+          - "k8s.io/component-helpers"
+          - "k8s.io/controller-manager"
+          - "k8s.io/cri-api"
+          - "k8s.io/csi-translation-lib"
+          - "k8s.io/kube-aggregator"
+          - "k8s.io/kube-controller-manager"
+          - "k8s.io/kube-proxy"
+          - "k8s.io/kube-scheduler"
+          - "k8s.io/kubectl"
+          - "k8s.io/kubelet"
+          - "k8s.io/legacy-cloud-providers"
+          - "k8s.io/metrics"
+          - "k8s.io/mount-utils"
+          - "k8s.io/pod-security-admission"
+          - "k8s.io/sample-apiserver"
+      non-k8s: # Group everything else together to minimize the number of PRs.
         patterns:
-          - "k8s.io/*"
+          - "*"
     labels:
       - go
       - dependencies


### PR DESCRIPTION
Follow up on https://github.com/kubernetes/dns/issues/691 on top of https://github.com/kubernetes/dns/pull/696 based on the discussion in https://github.com/kubernetes/dns/pull/697.