### PR TITLE
Add missing k8s.io/kubernetes to the k8s.io group in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,6 +44,7 @@ updates:
           - "k8s.io/kube-scheduler"
           - "k8s.io/kubectl"
           - "k8s.io/kubelet"
+          - "k8s.io/kubernetes"
           - "k8s.io/legacy-cloud-providers"
           - "k8s.io/metrics"
           - "k8s.io/mount-utils"


### PR DESCRIPTION
This fixes the omission described in https://github.com/kubernetes/dns/issues/691#issuecomment-2949727895.