### PR TITLE
Add timeouts plugin coredns

### DIFF
--- a/cmd/node-cache/main.go
+++ b/cmd/node-cache/main.go
@@ -46,6 +46,7 @@ import (
 	_ "github.com/coredns/coredns/plugin/reload"
 	_ "github.com/coredns/coredns/plugin/rewrite"
 	_ "github.com/coredns/coredns/plugin/template"
+	_ "github.com/coredns/coredns/plugin/timeouts"
 	_ "github.com/coredns/coredns/plugin/trace"
 	_ "github.com/coredns/coredns/plugin/whoami"
 	"k8s.io/dns/pkg/version"

--- a/vendor/github.com/coredns/coredns/plugin/pkg/durations/durations.go
+++ b/vendor/github.com/coredns/coredns/plugin/pkg/durations/durations.go
@@ -1,0 +1,26 @@
+package durations
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+)
+
+// NewDurationFromArg returns a time.Duration from a configuration argument
+// (string) which has come from the Corefile. The argument has some basic
+// validation applied before returning a time.Duration. If the argument has no
+// time unit specified and is numeric the argument will be treated as seconds
+// rather than GO's default of nanoseconds.
+func NewDurationFromArg(arg string) (time.Duration, error) {
+	_, err := strconv.Atoi(arg)
+	if err == nil {
+		arg = arg + "s"
+	}
+
+	d, err := time.ParseDuration(arg)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse duration '%s'", arg)
+	}
+
+	return d, nil
+}

--- a/vendor/github.com/coredns/coredns/plugin/timeouts/README.md
+++ b/vendor/github.com/coredns/coredns/plugin/timeouts/README.md
@@ -1,0 +1,89 @@
+# timeouts
+
+## Name
+
+*timeouts* - allows you to configure the server read, write and idle timeouts for the TCP, TLS, DoH and DoQ (idle only) servers.
+
+## Description
+
+CoreDNS is configured with sensible timeouts for server connections by default.
+However in some cases for example where CoreDNS is serving over a slow mobile
+data connection the default timeouts are not optimal.
+
+Additionally some routers hold open connections when using DNS over TLS or DNS
+over HTTPS. Allowing a longer idle timeout helps performance and reduces issues
+with such routers.
+
+The *timeouts* "plugin" allows you to configure CoreDNS server read, write and
+idle timeouts.
+
+## Syntax
+
+~~~ txt
+timeouts {
+	read DURATION
+	write DURATION
+	idle DURATION
+}
+~~~
+
+For any timeouts that are not provided, default values are used which may vary
+depending on the server type. At least one timeout must be specified otherwise
+the entire timeouts block should be omitted.
+
+## Examples
+
+Start a DNS-over-TLS server that picks up incoming DNS-over-TLS queries on port
+5553 and uses the nameservers defined in `/etc/resolv.conf` to resolve the
+query. This proxy path uses plain old DNS. A 10 second read timeout, 20
+second write timeout and a 60 second idle timeout have been configured.
+
+~~~
+tls://.:5553 {
+	tls cert.pem key.pem ca.pem
+	timeouts {
+		read 10s
+		write 20s
+		idle 60s
+	}
+	forward . /etc/resolv.conf
+}
+~~~
+
+Start a DNS-over-HTTPS server that is similar to the previous example. Only the
+read timeout has been configured for 1 minute.
+
+~~~
+https://. {
+	tls cert.pem key.pem ca.pem
+	timeouts {
+		read 1m
+	}
+	forward . /etc/resolv.conf
+}
+~~~
+
+Start a DNS-over-QUIC server that has the idle timeout set to two minutes.
+
+~~~
+quic://.:853 {
+	tls cert.pem key.pem ca.pem
+	timeouts {
+		idle 2m
+	}
+	forward . /etc/resolv.conf
+}
+~~~
+
+Start a standard TCP/UDP server on port 1053. A read and write timeout has been
+configured. The timeouts are only applied to the TCP side of the server.
+
+~~~
+.:1053 {
+	timeouts {
+		read 15s
+		write 30s
+	}
+	forward . /etc/resolv.conf
+}
+~~~

--- a/vendor/github.com/coredns/coredns/plugin/timeouts/timeouts.go
+++ b/vendor/github.com/coredns/coredns/plugin/timeouts/timeouts.go
@@ -1,0 +1,69 @@
+package timeouts
+
+import (
+	"time"
+
+	"github.com/coredns/caddy"
+	"github.com/coredns/coredns/core/dnsserver"
+	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/plugin/pkg/durations"
+)
+
+func init() { plugin.Register("timeouts", setup) }
+
+func setup(c *caddy.Controller) error {
+	err := parseTimeouts(c)
+	if err != nil {
+		return plugin.Error("timeouts", err)
+	}
+	return nil
+}
+
+func parseTimeouts(c *caddy.Controller) error {
+	config := dnsserver.GetConfig(c)
+
+	for c.Next() {
+		args := c.RemainingArgs()
+		if len(args) > 0 {
+			return plugin.Error("timeouts", c.ArgErr())
+		}
+
+		b := 0
+		for c.NextBlock() {
+			block := c.Val()
+			timeoutArgs := c.RemainingArgs()
+			if len(timeoutArgs) != 1 {
+				return c.ArgErr()
+			}
+
+			timeout, err := durations.NewDurationFromArg(timeoutArgs[0])
+			if err != nil {
+				return c.Err(err.Error())
+			}
+
+			if timeout < (1*time.Second) || timeout > (24*time.Hour) {
+				return c.Errf("timeout provided '%s' needs to be between 1 second and 24 hours", timeout)
+			}
+
+			switch block {
+			case "read":
+				config.ReadTimeout = timeout
+
+			case "write":
+				config.WriteTimeout = timeout
+
+			case "idle":
+				config.IdleTimeout = timeout
+
+			default:
+				return c.Errf("unknown option: '%s'", block)
+			}
+			b++
+		}
+
+		if b == 0 {
+			return plugin.Error("timeouts", c.Err("timeouts block with no timeouts specified"))
+		}
+	}
+	return nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -140,6 +140,7 @@ github.com/coredns/coredns/plugin/pkg/cidr
 github.com/coredns/coredns/plugin/pkg/dnstest
 github.com/coredns/coredns/plugin/pkg/dnsutil
 github.com/coredns/coredns/plugin/pkg/doh
+github.com/coredns/coredns/plugin/pkg/durations
 github.com/coredns/coredns/plugin/pkg/edns
 github.com/coredns/coredns/plugin/pkg/fall
 github.com/coredns/coredns/plugin/pkg/fuzz
@@ -163,6 +164,7 @@ github.com/coredns/coredns/plugin/reload
 github.com/coredns/coredns/plugin/rewrite
 github.com/coredns/coredns/plugin/template
 github.com/coredns/coredns/plugin/test
+github.com/coredns/coredns/plugin/timeouts
 github.com/coredns/coredns/plugin/trace
 github.com/coredns/coredns/plugin/whoami
 github.com/coredns/coredns/request


### PR DESCRIPTION
Hi Team!
Could you please enable the timeouts plugin for node-cache? 
It lets us set server-side read/write/idle timeouts in the Corefile and helps with slow/stuck TCP/DoT/DoH clients