### PR TITLE
Bump base images

### DIFF
--- a/images/dnsmasq/Makefile
+++ b/images/dnsmasq/Makefile
@@ -21,17 +21,19 @@ CONTAINER_PREFIX ?= k8s-dns
 ALL_ARCH := amd64 arm arm64 ppc64le s390x
 MANIFEST_IMAGE := $(REGISTRY)/$(CONTAINER_PREFIX)-dnsmasq
 IMAGE := $(CONTAINER_PREFIX)-dnsmasq-$(ARCH)
-COMPILE_IMAGE := registry.k8s.io/kube-cross:v1.7.6-k8s1.6-0
+# Find the correct tag at https://github.com/kubernetes/release/blob/master/images/build/cross/variants.yaml
+COMPILE_IMAGE := registry.k8s.io/build-image/kube-cross:v1.34.0-go1.24.9-bullseye.0
 OUTPUT_DIR := _output/$(ARCH)
 
 # Ensure that the docker command line supports the manifest images
 export DOCKER_CLI_EXPERIMENTAL=enabled
 
 # Multiarch image
-# Uploaded: May 19, 2025
-BASEIMAGE ?= gcr.io/distroless/base-debian12@sha256:cef75d12148305c54ef5769e6511a5ac3c820f39bf5c8a4fbfd5b76b4b8da843
+# Find the latest hash by opening in browser https://gcr.io/distroless/base-debian12:latest
+BASEIMAGE ?= gcr.io/distroless/base-debian12@sha256:9e9b50d2048db3741f86a48d939b4e4cc775f5889b3496439343301ff54cdba8
 ifeq ($(ARCH),amd64)
-	COMPILE_IMAGE := registry.k8s.io/build-image/debian-base-$(ARCH):bookworm-v1.0.4
+	# Find the correct tag at https://github.com/kubernetes/release/blob/master/images/build/debian-base/variants.yaml
+	COMPILE_IMAGE := registry.k8s.io/build-image/debian-base-$(ARCH):bookworm-v1.0.6
 else ifeq ($(ARCH),arm)
 	TRIPLE    ?= arm-linux-gnueabihf
 	QEMUARCH  := arm

--- a/rules.mk
+++ b/rules.mk
@@ -30,9 +30,10 @@ SRC_DIRS := cmd pkg
 
 ALL_ARCH := amd64 arm arm64 ppc64le s390x
 # Multiarch image
-# Debian distroless image uploaded on 2025-03-28
-BASEIMAGE ?= gcr.io/distroless/static-debian12@sha256:765ef30aff979959710073e7ba3b163d479a285d7d96d0020fca8c1501de48cb
-IPTIMAGE ?= registry.k8s.io/build-image/distroless-iptables:v0.6.12@sha256:a9bb141f06c2ad392cf308f826fba5f7dfd8b78a8e33eb275a6857e13bc130c6
+# Find the latest hash by opening in browser https://gcr.io/distroless/static-debian12:latest
+BASEIMAGE ?= gcr.io/distroless/static-debian12@sha256:87bce11be0af225e4ca761c40babb06d6d559f5767fbf7dc3c47f0f1a466b92c
+# Find the correct tag at https://github.com/kubernetes/release/blob/master/images/build/distroless-iptables/variants.yaml
+IPTIMAGE ?= registry.k8s.io/build-image/distroless-iptables:v0.7.10@sha256:1a19fbdbdb566bf26dd1e4f2f26c21db1a63991d5cb5d17f3ba158c8465810c1
 
 # These rules MUST be expanded at reference time (hence '=') as BINARY
 # is dynamically scoped.


### PR DESCRIPTION
Automated findings that lead me to make these bumps include: CVE-2025-4802, CVE-2025-9230, CVE-2025-9232, CVE-2025-8058

Additionally, distroless-iptables image is upgraded to its go1.24 variant to match the bump in Go version in #722

Upload dates are removed as half the time we forget to update them.